### PR TITLE
Fix value of seL4_MaxUntypedBits when emulating kernel boot

### DIFF
--- a/tool/microkit/util.py
+++ b/tool/microkit/util.py
@@ -66,7 +66,7 @@ class MemoryRegion:
     end: int
 
     def aligned_power_of_two_regions(self) -> List["MemoryRegion"]:
-        max_bits = 40
+        max_bits = 47
         # Align
         # find the first bit self
         r = []


### PR DESCRIPTION
I believe the variable `max_bits` corresponds to `seL4_MaxUntypedBits`. The value of this on AArch64 is 47 (see `seL4/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h`.

I have not run into issues because this value is not correct yet, but I thought I would try to fix it before having to debug something going wrong.