### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -1,0 +1,49 @@
+# Copyright 2023, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# It is to be noted that this CI workflow is temporary and simply attempts
+# to build (but not test) the SDK. It is only for the purposes of seeing
+# whether a particular commit has devastatingly broken the Microkit SDK
+
+name: SDK
+
+on:
+  # Run the SDK CI on any activity on the main branch as well as on any pull
+  # request activity (e.g when it is created and also when it is updated).
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build SDK (Linux x86-64)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Microkit repository
+        uses: actions/checkout@v3
+      - name: Checkout seL4 repository
+        uses: actions/checkout@v3
+        with:
+            repository: seL4/seL4
+            ref: microkit
+            path: seL4
+      - name: Install SDK dependencies
+        run: |
+          sudo apt update
+          sudo apt install \
+            cmake pandoc device-tree-compiler ninja-build \
+            texlive-fonts-recommended texlive-formats-extra libxml2-utils \
+            gcc-aarch64-linux-gnu python3.9 python3-pip python3.9-venv \
+            musl-tools
+      - name: Install AArch64 GCC toolchain
+        run: |
+          wget -O aarch64-toolchain.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz\?revision\=79f65c42-1a1b-43f2-acb7-a795c8427085\&hash\=61BBFB526E785D234C5D8718D9BA8E61
+          tar xf aarch64-toolchain.tar.gz
+          echo "$(pwd)/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Build SDK
+        run: |
+          python3.9 -m venv pyenv
+          ./pyenv/bin/pip install --upgrade pip setuptools wheel
+          ./pyenv/bin/pip install -r requirements.txt
+          ./pyenv/bin/python build_sdk.py --sel4=seL4


### PR DESCRIPTION
This patch attempts to bring basic CI to seL4CP. Currently, it only builds the SDK and then uploads the artefact for anyone to be able to download.

An example of a CI run is here: https://github.com/Ivan-Velickovic/sel4cp/actions/runs/4602867006.

There are some costs to consider with using GitHub provided CI however.
* They run in a virtualised environment, with other dependencies already installed and possibly other configuration that does not match the environment that a developer would use when building/using the SDK.
* It is quite slow, takes about 5-6 minutes on a GitHub runner vs about one minute on my personal computer. Some of this time is due to having to install the dependencies each time the CI is run, which might actually be a good thing.
* One of the issues I generally have with CI is that it is often hard to reproduce. In this patch all the setup is done in GitHub's YAML format, alternatively, we could do most of the setup in a shell script. This way people should be able to reproduce the CI results themselves, also it would make it easier for anyone wanting to set up their own CI for seL4CP.

Other aspects to discuss:
* Not sure whether we want to upload a prebuilt SDK for every commit (which would be done with this patch), or just for proper releases.
* What to do with the current code under `tests/`. Should all the tests under that directory be built for every platform and then simulated?
