### PR TITLE
Add option to declare IRQ as "edge" triggered

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -479,6 +479,7 @@ The `irq` element has the following attributes:
 
 * `irq`: The hardware interrupt number.
 * `id`: The channel identifier. Must be at least 0 and less than 63.
+* `trigger`: (optional) Whether the IRQ is edge triggered ("edge") or level triggered ("level"). Defaults to "level".
 
 The `setvar` element has the following attributes:
 

--- a/tool/microkit/__main__.py
+++ b/tool/microkit/__main__.py
@@ -64,7 +64,7 @@ from microkit.sel4 import (
     Sel4CnodeMint,
     Sel4CnodeCopy,
     Sel4UntypedRetype,
-    Sel4IrqControlGet,
+    Sel4IrqControlGetTrigger,
     Sel4IrqHandlerSetNotification,
     Sel4SchedControlConfigureFlags,
     emulate_kernel_boot,
@@ -1173,9 +1173,10 @@ def build_system(
         for sysirq in pd.irqs:
             cap_address = system_cap_address_mask | cap_slot
             system_invocations.append(
-                Sel4IrqControlGet(
+                Sel4IrqControlGetTrigger(
                     IRQ_CONTROL_CAP_ADDRESS,
                     sysirq.irq,
+                    sysirq.trigger.value,
                     root_cnode_cap,
                     cap_address,
                     kernel_config.cap_address_bits

--- a/tool/microkit/sel4.py
+++ b/tool/microkit/sel4.py
@@ -158,6 +158,11 @@ def calculate_rootserver_size(initial_task_region: MemoryRegion) -> int:
     return size
 
 
+class Sel4ArmIrqTrigger(IntEnum):
+    Level = 0
+    Edge = 1
+
+
 class Sel4Aarch64Regs:
     """
 typedef struct seL4_UserContext_ {
@@ -528,13 +533,14 @@ class Sel4AsidPoolAssign(Sel4Invocation):
 
 
 @dataclass
-class Sel4IrqControlGet(Sel4Invocation):
+class Sel4IrqControlGetTrigger(Sel4Invocation):
     _object_type = "IRQ Control"
     _method_name = "Get"
     _extra_caps = ("dest_root", )
-    label = Sel4Label.IRQIssueIRQHandler
+    label = Sel4Label.ARMIRQIssueIRQHandlerTrigger
     irq_control: int
     irq: int
+    trigger: int
     dest_root: int
     dest_index: int
     dest_depth: int

--- a/tool/test/__init__.py
+++ b/tool/test/__init__.py
@@ -101,6 +101,9 @@ class ProtectionDomainParseTests(ExtendedTestCase):
     def test_write_only_mr(self):
         self._check_error("pd_write_only_mr.xml", f"Error: perms must not be 'w', write-only mappings are not allowed on element 'map':")
 
+    def test_irq_invalid_trigger(self):
+        self._check_error("irq_invalid_trigger.xml", "Error: trigger must be either 'level' or 'edge' on element 'irq'")
+
 
 class ChannelParseTests(ExtendedTestCase):
     def test_missing_pd(self):

--- a/tool/test/irq_invalid_trigger.xml
+++ b/tool/test/irq_invalid_trigger.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+        <irq irq="1" id="1" trigger="an_invalid_trigger" />
+    </protection_domain>
+</system>


### PR DESCRIPTION
Currently all interrupts are registered as level-triggered, this patch enables users to specify a interrupt in the system description as edge-triggered instead.

One alternative solution would be to look at the device tree for the interrupt trigger type instead.