### PR TITLE
Making board and example arguments in dev_build.py required

### DIFF
--- a/dev_build.py
+++ b/dev_build.py
@@ -60,11 +60,13 @@ def main():
     )
     parser.add_argument(
         "--board",
-        help="Target board"
+        help="Target board",
+        required=True
     )
     parser.add_argument(
         "--example",
-        help="Example to build"
+        help="Example to build",
+        required=True
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Both these arguments are required, invoking the `dev_build.py` script without them causes a confusing error. This patch fixes that.