### PR TITLE
Remove redundant `-DKernelPlatform` when building seL4

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -192,12 +192,11 @@ def build_sel4(
         config_strs.append(s)
     config_str = " ".join(config_strs)
 
-    platform = board.name
     cmd = (
         f"cmake -GNinja -DCMAKE_INSTALL_PREFIX={sel4_install_dir.absolute()} "
         f" -DPYTHON3={executable} "
         f" -DCROSS_COMPILER_PREFIX={TOOLCHAIN_PREFIX}"
-        f" -DKernelPlatform={platform} {config_str} "
+        f" {config_str} "
         f"-S {sel4_dir.absolute()} -B {sel4_build_dir.absolute()}")
 
     r = system(cmd)


### PR DESCRIPTION
The `board.name` may not actually be the name of a valid seL4 platform so this is wrong, in addition `KernelPlatform` is provided by each supported platform's kernel options.