### PR TITLE
Fix config option used in ifdef for seL4 debug printing

### DIFF
--- a/libmicrokit/src/dbg.c
+++ b/libmicrokit/src/dbg.c
@@ -11,7 +11,7 @@
 void
 microkit_dbg_putc(int c)
 {
-#if defined(CONFIG_DEBUG_BUILD)
+#if defined(CONFIG_PRINTING)
     seL4_DebugPutChar(c);
 #endif
 }

--- a/monitor/src/util.c
+++ b/monitor/src/util.c
@@ -10,7 +10,7 @@
 void
 putc(uint8_t ch)
 {
-#if defined(CONFIG_DEBUG_BUILD)
+#if defined(CONFIG_PRINTING)
     seL4_DebugPutChar(ch);
 #endif
 }


### PR DESCRIPTION
It should be `CONFIG_PRINTING` as a debug build of the kernel does not necessarily have printing enabled (although this is a rare case and I only ran into it when debugging something with a debug kernel with printing intentionally disabled).
