### PR TITLE
libmicrokit: fix to successfully link on LLD

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -312,13 +312,6 @@ def build_lib_component(
     # Make output read-only
     dest.chmod(0o444)
 
-    crt0 = build_dir / "crt0.o"
-    dest = lib_dir / "crt0.o"
-    dest.unlink(missing_ok=True)
-    copy(crt0, dest)
-    # Make output read-only
-    dest.chmod(0o444)
-
     include_dir = root_dir / "board" / board.name / config.name / "include"
     source_dir = Path(component_name) / "include"
     for p in source_dir.rglob("*"):

--- a/libmicrokit/Makefile
+++ b/libmicrokit/Makefile
@@ -15,8 +15,7 @@ TOOLCHAIN := aarch64-none-elf-
 CFLAGS := -std=gnu11 -g3 -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Wno-unused-function -Werror -Iinclude -I$(SEL4_SDK)/include
 
 LIBS := libmicrokit.a
-OBJS := main.o dbg.o
-OTHER_OBJS :=  crt0.o
+OBJS := main.o crt0.o dbg.o
 
 $(BUILD_DIR)/%.o : src/%.S
 	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
@@ -29,7 +28,7 @@ $(BUILD_DIR)/%.o : src/%.c
 
 LIB = $(addprefix $(BUILD_DIR)/, $(LIBS))
 
-all: $(LIB) $(addprefix $(BUILD_DIR)/, $(OTHER_OBJS))
+all: $(LIB)
 
 $(LIB): $(addprefix $(BUILD_DIR)/, $(OBJS))
 	$(TOOLCHAIN)ar -rv $@ $^

--- a/libmicrokit/microkit.ld
+++ b/libmicrokit/microkit.ld
@@ -11,8 +11,6 @@ PHDRS
 
 ENTRY(_start);
 
-STARTUP(crt0.o);
-
 SECTIONS
 {
     . = 0x200000;


### PR DESCRIPTION
LLD does not recognise the STARTUP directive which works with the GNU linker. Given that the crt0.s entry point is already specified to be at the start of the _text section when linking with libmicrokit, all we need to do is slightly change the Makefile to also include crt0.o when linking to produce libmicrokit.a