### PR TITLE
dev_build: add option to explicitly pass config

### DIFF
--- a/dev_build.py
+++ b/dev_build.py
@@ -15,8 +15,6 @@ from sys import executable
 CWD = Path.cwd()
 BUILD_DIR = CWD / "tmp_build"
 
-microkit_config = "debug"
-
 
 def find_releases():
     releases = []
@@ -68,6 +66,11 @@ def main():
         help="Example to build",
         required=True
     )
+    parser.add_argument(
+        "--config",
+        default="debug",
+        help="Config option to be passed to the tool"
+    )
     args = parser.parse_args()
 
     # TODO: Support choosing a release by specifying on command line
@@ -83,7 +86,7 @@ def main():
     make_env = environ.copy()
     make_env["BUILD_DIR"] = str(BUILD_DIR.absolute())
     make_env["MICROKIT_BOARD"] = args.board
-    make_env["MICROKIT_CONFIG"] = microkit_config
+    make_env["MICROKIT_CONFIG"] = args.config
     make_env["MICROKIT_SDK"] = str(release)
 
     # Choose the makefile based on the `--example-from-sdk` command line flag


### PR DESCRIPTION
Useful for debugging/testing the release configuration.