### PR TITLE
tool: Add `__str__` and `__repr__` methods to `Sel4Aarch64Regs`

### DIFF
--- a/tool/microkit/sel4.py
+++ b/tool/microkit/sel4.py
@@ -303,6 +303,11 @@ typedef struct seL4_UserContext_ {
         )
         return tuple(0 if x is None else x for x in raw)
 
+    def __str__(self):
+        return self.as_tuple().__str__()
+
+    def __repr__(self):
+        return self.as_tuple().__repr__()
 
 class Sel4Label(IntEnum):
     # Untyped


### PR DESCRIPTION
`Sel4Aarch64Regs` are appended to reports using `str()`. Without these methods, the report doesn't contain any useful information about them.