### PR TITLE
Omit assembler debug level to improve toolchain compatability

### DIFF
--- a/libmicrokit/Makefile
+++ b/libmicrokit/Makefile
@@ -22,7 +22,7 @@ $(BUILD_DIR)/%.o : src/%.S
 	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
-	$(TOOLCHAIN)as -g3 -mcpu=$(GCC_CPU) $< -o $@
+	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.c
 	$(TOOLCHAIN)gcc -c $(CFLAGS) $< -o $@

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -32,7 +32,7 @@ $(BUILD_DIR)/%.o : src/%.S
 	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
-	$(TOOLCHAIN)as -g3 -mcpu=$(GCC_CPU) $< -o $@
+	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.c
 	$(TOOLCHAIN)gcc -c $(CFLAGS)  $< -o $@

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -22,7 +22,7 @@ $(BUILD_DIR)/%.o : src/%.S
 	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
-	$(TOOLCHAIN)as -g3 -mcpu=$(GCC_CPU) $< -o $@
+	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.c
 	$(TOOLCHAIN)gcc -c $(CFLAGS)  $< -o $@


### PR DESCRIPTION
More recent versions of `aarch64-none-elf-as` don't support passing a debug level to `-g`.

Specifically, GNU Binutils 2.40 (associated with GCC 12.3) doesn't support this.