### PR TITLE
monitor: Increase BOOTSTRAP_INVOCATION_DATA_SIZE

### DIFF
--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -79,7 +79,7 @@
  *
  * FIXME: This can be smaller once compression is enabled.
  */
-#define BOOTSTRAP_INVOCATION_DATA_SIZE 110
+#define BOOTSTRAP_INVOCATION_DATA_SIZE 150
 
 seL4_IPCBuffer *__sel4_ipc_buffer;
 


### PR DESCRIPTION
To enable protection domains with larger memory footprints.

https://github.com/seL4/rust-microkit-http-server-demo, for example, requires at least 122 `seL4_Word`s.