### PR TITLE
tool: Handle unaligned PD segments

### DIFF
--- a/tool/microkit/__main__.py
+++ b/tool/microkit/__main__.py
@@ -1001,7 +1001,8 @@ def build_system(
             if not segment.loadable:
                 continue
 
-            regions.append(Region(f"PD-ELF {pd.name}-{seg_idx}", phys_addr_next, segment.data))
+            segment_phys_addr = phys_addr_next + (segment.virt_addr % kernel_config.minimum_page_size)
+            regions.append(Region(f"PD-ELF {pd.name}-{seg_idx}", segment_phys_addr, segment.data))
 
             perms = ""
             if segment.is_readable:


### PR DESCRIPTION
Correctly handle PD segments whose start vaddrs do not lie on page boundaries.