### PR TITLE
[c-parser] remove continue statement

### DIFF
--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -464,7 +464,7 @@ static void monitor(void)
             cont = true;
         }
 
-        if(cont == false) {
+        if (cont == false) {
             if (badge < MAX_PDS && pd_names[badge][0] != 0) {
                 puts("faulting PD: ");
                 puts(pd_names[badge]);


### PR DESCRIPTION
I needed to make this change to make the C-parser accept the code.
Not entirely sure why the C-parser blew up when it saw the continue statement, I am unsure if this is a bug in the C-parser or just not supported by it. 