### PR TITLE
Minor manual fixes

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -576,13 +576,19 @@ When debugging is enabled the kernel will use the same UART as U-Boot.
 
 ## ZCU102
 
-Initial support is available for the ZCU102.
+Initial support is available for the Xilinx ZCU102.
 
 **FIXME:** Additional documentation required here.
 
 The ZCU102 can run on a physical board or on an appropriate QEMU based emulator.
 
-An QEMU command line:
+Microkit produces a raw binary file, so when using U-Boot you must execute the image using:
+
+    => go 0x40000000
+
+Note that the loading address must be `0x40000000`.
+
+For simulating the ZCU102 using QEMU, use the following command:
 
     $ qemu-system-aarch64 \
        -m 4G  \

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -527,7 +527,7 @@ The MBa8Xx provides access to the TQMa8XQP UART via UART-USB bridge.
 To access the UART connect a USB micro cable to port **X13**.
 The UART-USB bridge supports 4 individual UARTs; the UART is connected to the 2nd port.
 
-By default the SoM will autoboot using U-boot.
+By default the SoM will autoboot using U-Boot.
 Hit any key during the boot process to stop the autoboot.
 
 A new board will autoboot to Linux.
@@ -540,7 +540,7 @@ The board can be reset by pressing switch **S4** (located next to the Ethernet p
 Alternatively, you can use the `reset` command from the U-Boot prompt.
 
 During development the most convenient way to boot a Microkit image is via network booting.
-U-boot support booting via the *tftp* protocol.
+U-Boot support booting via the *tftp* protocol.
 To support this you'll want to configure the network.
 U-Boot supports DHCP, however it is often more reliable to explicitly set an IP address.
 For example:

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -539,7 +539,7 @@ You will likely want to disable autoboot:
 The board can be reset by pressing switch **S4** (located next to the Ethernet port).
 Alternatively, you can use the `reset` command from the U-Boot prompt.
 
-During development the most convenient way to boot an Microkit image is via network booting.
+During development the most convenient way to boot a Microkit image is via network booting.
 U-boot support booting via the *tftp* protocol.
 To support this you'll want to configure the network.
 U-Boot supports DHCP, however it is often more reliable to explicitly set an IP address.


### PR DESCRIPTION
Fixes spelling mistakes and adds instructions for booting on ZCU102 hardware. Closes https://github.com/seL4/microkit/issues/30.

In the future we need to find out how to integrate the documentation for each board with the official seL4 documentation. Including how to setup U-Boot etc is too much for the Microkit manual most likely but I still believe that the manual should include instructions specific to Microkit should remain in the manual.