### PR TITLE
Fixes and cleanup in passive server example

### DIFF
--- a/example/imx8mm/passive_server/client.c
+++ b/example/imx8mm/passive_server/client.c
@@ -10,14 +10,13 @@
 
 void init(void)
 {
-    microkit_dbg_puts("client: client protection domain init function running\n");
+    microkit_dbg_puts("CLIENT|INFO: init function running\n");
 
     /* message the server */
-    microkit_mr_set(0, 0);
     (void) microkit_ppcall(SERVER_CH, microkit_msginfo_new(1, 1));
 }
 
 void notified(microkit_channel ch)
 {
-    microkit_dbg_puts("client: recieved a notification on an unexpected channel\n");
+    microkit_dbg_puts("CLIENT|INFO: recieved a notification on an unexpected channel\n");
 }

--- a/example/imx8mm/passive_server/server.c
+++ b/example/imx8mm/passive_server/server.c
@@ -9,11 +9,11 @@
 microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
 {
     switch (microkit_msginfo_get_label(msginfo)) {
-    case 0:
-        microkit_dbg_puts("server: is running on clients scheduling context\n");
+    case 1:
+        microkit_dbg_puts("SERVER|INFO: running on clients scheduling context\n");
         break;
     default:
-        microkit_dbg_puts("server: received an unexpected message\n");
+        microkit_dbg_puts("SERVER|ERROR: received an unexpected message\n");
     }
 
     return seL4_MessageInfo_new(0, 0, 0, 0);
@@ -21,11 +21,11 @@ microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
 
 void init(void)
 {
-    microkit_dbg_puts("server: server protection domain init function running\n");
+    microkit_dbg_puts("SERVER|INFO: init function running\n");
     /* Nothing to initialise */
 }
 
 void notified(microkit_channel ch)
 {
-    microkit_dbg_puts("server: recieved a notification on an unexpected channel\n");
+    microkit_dbg_puts("SERVER|ERROR: recieved a notification on an unexpected channel\n");
 }


### PR DESCRIPTION
Making the style consistent with other examples and fixing the server code such that it prints the right message when getting a PPC from the client.