### PR TITLE
tool: print out values of TCB registers in report

### DIFF
--- a/tool/microkit/__main__.py
+++ b/tool/microkit/__main__.py
@@ -262,6 +262,15 @@ def invocation_to_str(inv: Sel4Invocation, cap_lookup: Dict[int, str]) -> str:
                 val_str = f"{val} ({object_type_name} - variable size)"
             else:
                 val_str = f"{val} ({object_type_name} - 0x{object_size:x})"
+        elif nm == "regs":
+            regs = vars(inv.regs)
+            val_str = ""
+            for i, reg in enumerate(regs.items()):
+                reg_value = 0 if reg[1] is None else reg[1]
+                if i == 0:
+                    val_str = f"{reg[0]}: 0x{reg_value:016x}"
+                else:
+                    val_str += f"\n{' ':30s}{reg[0]}: 0x{reg_value:016x}"
         else:
             val_str = str(val)
         arg_strs.append(f"         {nm:20s} {val_str}")


### PR DESCRIPTION
Before:
```
    0x001f TCB                  - WriteRegisters    - 0x8000000000000006 (TCB: PD=hello)
         resume               False
         arch_flags           0
         regs                 <microkit.sel4.Sel4Aarch64Regs object at 0x7f4eeed85880>
```

After:
```
    0x001f TCB                  - WriteRegisters    - 0x8000000000000006 (TCB: PD=hello)
         resume               False
         arch_flags           0
         regs                 pc: 0x0000000000200000
                              sp: 0x0000000000000000
                              spsr: 0x0000000000000000
                              x0: 0x0000000000000000
                              x1: 0x0000000000000000
                              x2: 0x0000000000000000
                              x3: 0x0000000000000000
                              x4: 0x0000000000000000
                              x5: 0x0000000000000000
                              x6: 0x0000000000000000
                              x7: 0x0000000000000000
                              x8: 0x0000000000000000
                              x16: 0x0000000000000000
                              x17: 0x0000000000000000
                              x18: 0x0000000000000000
                              x29: 0x0000000000000000
                              x30: 0x0000000000000000
                              x9: 0x0000000000000000
                              x10: 0x0000000000000000
                              x11: 0x0000000000000000
                              x12: 0x0000000000000000
                              x13: 0x0000000000000000
                              x14: 0x0000000000000000
                              x15: 0x0000000000000000
                              x19: 0x0000000000000000
                              x20: 0x0000000000000000
                              x21: 0x0000000000000000
                              x22: 0x0000000000000000
                              x23: 0x0000000000000000
                              x24: 0x0000000000000000
                              x25: 0x0000000000000000
                              x26: 0x0000000000000000
                              x27: 0x0000000000000000
                              x28: 0x0000000000000000
                              tpidr_el0: 0x0000000000000000
                              tpidrro_el0: 0x0000000000000000
```