### PR TITLE
Remove taking the address of local variables

### DIFF
--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -45,6 +45,7 @@ static void run_init_funcs(void)
     }
 }
 
+seL4_Word gbadge;
 static void handler_loop(void)
 {
     bool have_reply = false;
@@ -55,7 +56,8 @@ static void handler_loop(void)
         seL4_MessageInfo_t tag;
 
         if (have_reply) {
-            tag = seL4_ReplyRecv(INPUT_CAP, reply_tag, &badge, REPLY_CAP);
+            tag = seL4_ReplyRecv(INPUT_CAP, reply_tag, &gbadge, REPLY_CAP);
+            badge = gbadge;
         } else if (have_signal) {
             tag = seL4_NBSendRecv(signal, signal_msg, INPUT_CAP, &badge, REPLY_CAP);
             have_signal = false;

--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -429,14 +429,19 @@ static unsigned perform_invocation(seL4_Word *invocation_data, unsigned offset, 
     return next_offset;
 }
 
+seL4_Word gbadge;
+seL4_UserContext gregs;
 static void monitor(void)
 {
     for (;;) {
-        seL4_Word badge, label;
+        seL4_Word badge;
+        seL4_Word label;
         seL4_MessageInfo_t tag;
         seL4_Error err;
 
-        tag = seL4_Recv(fault_ep, &badge, reply);
+        tag = seL4_Recv(fault_ep, &gbadge, reply);
+        badge = gbadge;
+
         label = seL4_MessageInfo_get_label(tag);
 
         seL4_Word tcb_cap = tcbs[badge];
@@ -473,10 +478,11 @@ static void monitor(void)
 
         seL4_UserContext regs;
 
-        err = seL4_TCB_ReadRegisters(tcb_cap, false, 0, sizeof(seL4_UserContext) / sizeof(seL4_Word), &regs);
+        err = seL4_TCB_ReadRegisters(tcb_cap, false, 0, sizeof(seL4_UserContext) / sizeof(seL4_Word), &gregs);
         if (err != seL4_NoError) {
             fail("error reading registers");
         }
+        regs = gregs;
 
         // FIXME: Would be good to print the whole register set
         puts("Registers: \n");


### PR DESCRIPTION
This is a change needed to verify the code (see [this](https://docs.sel4.systems/processes/style-guide.html#verification-requirements)  page on C parser restrictions), instead of taking the address of local variables we should take the address of a global variable and then copy it over to a local variable. This copy itself isn't really needed, but makes the proof somewhat nicer to express.