### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -37,9 +37,9 @@ jobs:
             python3.9 python3-pip python3.9-venv musl-tools
       - name: Install AArch64 GCC toolchain
         run: |
-          wget -O aarch64-toolchain.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz\?revision\=79f65c42-1a1b-43f2-acb7-a795c8427085\&hash\=61BBFB526E785D234C5D8718D9BA8E61
+          wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf.tar.xz%3Frev%3D28d5199f6db34e5980aae1062e5a6703%26hash%3DF6F5604BC1A2BBAAEAC4F6E98D8DC35B
           tar xf aarch64-toolchain.tar.gz
-          echo "$(pwd)/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+          echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Build SDK
         run: |
           python3.9 -m venv pyenv
@@ -62,9 +62,9 @@ jobs:
         run: brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive
       - name: Install AArch64 GCC toolchain
         run: |
-          wget -O aarch64-toolchain.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz?rev=51c39c753f8c4a54875b7c5dccfb84ef&hash=DB5BC5D16E3FE6AB60E8F51B97CE5777
+          wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D09b11f159fc24fdda01e05bb32695dd5%26hash%3D6AAF4239F28AE17389AB3E611DFFE0A6
           tar xf aarch64-toolchain.tar.gz
-          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+          echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Build SDK
         run: |
           python3.9 -m venv pyenv
@@ -87,9 +87,9 @@ jobs:
         run: brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive
       - name: Install AArch64 GCC toolchain
         run: |
-          wget -O aarch64-toolchain.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz?rev=51c39c753f8c4a54875b7c5dccfb84ef&hash=DB5BC5D16E3FE6AB60E8F51B97CE5777
+          wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D09b11f159fc24fdda01e05bb32695dd5%26hash%3D6AAF4239F28AE17389AB3E611DFFE0A6
           tar xf aarch64-toolchain.tar.gz
-          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+          echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Build SDK
         run: |
           python3.9 -m venv pyenv

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -16,7 +16,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build_linux_x64:
     name: Build SDK (Linux x86-64)
     runs-on: ubuntu-20.04
     steps:
@@ -46,3 +46,53 @@ jobs:
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt
           ./pyenv/bin/python build_sdk.py --sel4=seL4
+  build_macos_x64:
+    name: Build SDK (macOS x86-64)
+    runs-on: macos-12
+    steps:
+      - name: Checkout Microkit repository
+        uses: actions/checkout@v3
+      - name: Checkout seL4 repository
+        uses: actions/checkout@v3
+        with:
+            repository: seL4/seL4
+            ref: microkit
+            path: seL4
+      - name: Install SDK dependencies
+        run: brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive
+      - name: Install AArch64 GCC toolchain
+        run: |
+          wget -O aarch64-toolchain.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz?rev=51c39c753f8c4a54875b7c5dccfb84ef&hash=DB5BC5D16E3FE6AB60E8F51B97CE5777
+          tar xf aarch64-toolchain.tar.gz
+          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Build SDK
+        run: |
+          python3.9 -m venv pyenv
+          ./pyenv/bin/pip install --upgrade pip setuptools wheel
+          ./pyenv/bin/pip install -r requirements.txt
+          ./pyenv/bin/python build_sdk.py --sel4=seL4
+  build_macos_arm64:
+    name: Build SDK (macOS ARM64)
+    runs-on: macos-12
+    steps:
+      - name: Checkout Microkit repository
+        uses: actions/checkout@v3
+      - name: Checkout seL4 repository
+        uses: actions/checkout@v3
+        with:
+            repository: seL4/seL4
+            ref: microkit
+            path: seL4
+      - name: Install SDK dependencies
+        run: brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive
+      - name: Install AArch64 GCC toolchain
+        run: |
+          wget -O aarch64-toolchain.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz?rev=51c39c753f8c4a54875b7c5dccfb84ef&hash=DB5BC5D16E3FE6AB60E8F51B97CE5777
+          tar xf aarch64-toolchain.tar.gz
+          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Build SDK
+        run: |
+          python3.9 -m venv pyenv
+          ./pyenv/bin/pip install --upgrade pip setuptools wheel
+          ./pyenv/bin/pip install -r requirements.txt
+          ./pyenv/bin/python build_sdk.py --sel4=seL4 --tool-target-triple=aarch64-apple-darwin

--- a/README.md
+++ b/README.md
@@ -62,13 +62,18 @@ At this point in time this is not fully realised, however it is a high priority 
 
 The ARM toolchain is available from:
 
-https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads/10-2-2020-11
+https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads.
 
-The specific version used for development is the x86_64-aarch64-none-elf version:
+Development is done with the aarch64-none-elf- toolchain.
 
-https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz?revision=79f65c42-1a1b-43f2-acb7-a795c8427085&hash=61BBFB526E785D234C5D8718D9BA8E61
+On Linux x86-64 the following version is used:
+https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf.tar.xz?rev=28d5199f6db34e5980aae1062e5a6703&hash=F6F5604BC1A2BBAAEAC4F6E98D8DC35B
 
-Note: There are no plans to support development of Microkit on any platforms other than Linux x86_64.
+On macOS Apple Silicon/AArch64 the following version is used:
+https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-darwin-arm64-aarch64-none-elf.tar.xz?rev=c5523a33dc7e49278f2a943a6a9822c4&hash=6DC6989BB1E6A9C7F8CBFEAA84842FA1
+
+On macOS Intel/x86-64 the following version is used:
+https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz?rev=09b11f159fc24fdda01e05bb32695dd5&hash=6AAF4239F28AE17389AB3E611DFFE0A6
 
 ## seL4 Version
 

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from sys import executable
 from tarfile import open as tar_open, TarInfo
+import platform as host_platform
 
 from typing import Dict, Union, List, Tuple
 
@@ -175,12 +176,27 @@ def build_tool(tool_target: Path) -> None:
     pyoxidizer = ENV_BIN_DIR / "pyoxidizer"
     if not pyoxidizer.exists():
         raise Exception("pyoxidizer does not appear to be installed in your Python environment")
+
+    host_system = host_platform.system()
+    if host_system == "Linux":
+        target_triple = "x86_64-unknown-linux-musl"
+    elif host_system == "Darwin":
+        host_arch = host_platform.machine()
+        if host_arch == "x86_64":
+            target_triple = "x86_64-apple-darwin"
+        elif host_arch == "arm64":
+            target_triple = "aarch64-apple-darwin"
+        else:
+            raise Exception(f"Unexpected Darwin architecture: {host_arch}")
+    else:
+        raise Exception(f"The platform \"{host_system}\" is not supported")
+
     r = system(
-        f"{pyoxidizer} build --release --path tool --target-triple x86_64-unknown-linux-musl"
+        f"{pyoxidizer} build --release --path tool --target-triple {target_triple}"
     )
     assert r == 0
 
-    tool_output = "./tool/build/x86_64-unknown-linux-musl/release/install/microkit"
+    tool_output = f"./tool/build/{target_triple}/release/install/microkit"
 
     r = system(f"strip {tool_output}")
     assert r == 0

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -165,6 +165,22 @@ def tar_filter(tarinfo: TarInfo) -> TarInfo:
     return tarinfo
 
 
+def get_tool_target_triple() -> str:
+    host_system = host_platform.system()
+    if host_system == "Linux":
+        return "x86_64-unknown-linux-musl"
+    elif host_system == "Darwin":
+        host_arch = host_platform.machine()
+        if host_arch == "x86_64":
+            return "x86_64-apple-darwin"
+        elif host_arch == "arm64":
+            return "aarch64-apple-darwin"
+        else:
+            raise Exception(f"Unexpected Darwin architecture: {host_arch}")
+    else:
+        raise Exception(f"The platform \"{host_system}\" is not supported")
+
+
 def test_tool() -> None:
     r = system(
         f"{executable} -m unittest discover -s tool -v"
@@ -172,24 +188,10 @@ def test_tool() -> None:
     assert r == 0
 
 
-def build_tool(tool_target: Path) -> None:
+def build_tool(tool_target: Path, target_triple: str) -> None:
     pyoxidizer = ENV_BIN_DIR / "pyoxidizer"
     if not pyoxidizer.exists():
         raise Exception("pyoxidizer does not appear to be installed in your Python environment")
-
-    host_system = host_platform.system()
-    if host_system == "Linux":
-        target_triple = "x86_64-unknown-linux-musl"
-    elif host_system == "Darwin":
-        host_arch = host_platform.machine()
-        if host_arch == "x86_64":
-            target_triple = "x86_64-apple-darwin"
-        elif host_arch == "arm64":
-            target_triple = "aarch64-apple-darwin"
-        else:
-            raise Exception(f"Unexpected Darwin architecture: {host_arch}")
-    else:
-        raise Exception(f"The platform \"{host_system}\" is not supported")
 
     r = system(
         f"{pyoxidizer} build --release --path tool --target-triple {target_triple}"
@@ -370,6 +372,7 @@ def build_lib_component(
 def main() -> None:
     parser = ArgumentParser()
     parser.add_argument("--sel4", type=Path, required=True)
+    parser.add_argument("--tool-target-triple", default=get_tool_target_triple(), help="Compile the Microkit tool for this target triple")
     args = parser.parse_args()
     sel4_dir = args.sel4.expanduser()
     if not sel4_dir.exists():
@@ -415,7 +418,7 @@ def main() -> None:
 
     if not tool_target.exists():
         test_tool()
-        build_tool(tool_target)
+        build_tool(tool_target, args.tool_target_triple)
 
     build_doc(root_dir)
 

--- a/example/imx8mm_evk/passive_server/Makefile
+++ b/example/imx8mm_evk/passive_server/Makefile
@@ -34,7 +34,7 @@ CLIENT_OBJS := client.o
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 
 IMAGES := server.elf client.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := -lmicrokit -Tmicrokit.ld
 
@@ -47,7 +47,7 @@ $(BUILD_DIR)/%.o: %.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 $(BUILD_DIR)/server.elf: $(addprefix $(BUILD_DIR)/, $(SERVER_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@

--- a/example/maaxboard/hello/Makefile
+++ b/example/maaxboard/hello/Makefile
@@ -33,7 +33,7 @@ HELLO_OBJS := hello.o
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 
 IMAGES := hello.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := -lmicrokit -Tmicrokit.ld
 
@@ -46,7 +46,7 @@ $(BUILD_DIR)/%.o: %.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 $(BUILD_DIR)/hello.elf: $(addprefix $(BUILD_DIR)/, $(HELLO_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@

--- a/example/tqma8xqp1gb/ethernet/Makefile
+++ b/example/tqma8xqp1gb/ethernet/Makefile
@@ -35,7 +35,7 @@ GPT_OBJS := gpt.o
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 
 IMAGES := eth.elf pass.elf gpt.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := -lmicrokit -Tmicrokit.ld
 
@@ -48,7 +48,7 @@ $(BUILD_DIR)/%.o: %.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 $(BUILD_DIR)/eth.elf: $(addprefix $(BUILD_DIR)/, $(ETH_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@

--- a/example/zcu102/hello/Makefile
+++ b/example/zcu102/hello/Makefile
@@ -33,7 +33,7 @@ HELLO_OBJS := hello.o
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 
 IMAGES := hello.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := -lmicrokit -Tmicrokit.ld
 
@@ -46,7 +46,7 @@ $(BUILD_DIR)/%.o: %.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 $(BUILD_DIR)/hello.elf: $(addprefix $(BUILD_DIR)/, $(HELLO_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@

--- a/libmicrokit/Makefile
+++ b/libmicrokit/Makefile
@@ -12,13 +12,13 @@ $(error GCC_CPU must be specified)
 endif
 
 TOOLCHAIN := aarch64-none-elf-
-CFLAGS := -std=gnu11 -g3 -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Wno-unused-function -Werror -Iinclude -I$(SEL4_SDK)/include
+CFLAGS := -std=gnu11 -g -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Wno-unused-function -Werror -Iinclude -I$(SEL4_SDK)/include
 
 LIBS := libmicrokit.a
 OBJS := main.o crt0.o dbg.o
 
 $(BUILD_DIR)/%.o : src/%.S
-	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
+	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g  -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
 	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -21,7 +21,7 @@ endif
 
 
 TOOLCHAIN := aarch64-none-elf-
-CFLAGS := -std=gnu11 -g3 -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -DBOARD_$(BOARD) -Wall -Werror
+CFLAGS := -std=gnu11 -g -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -DBOARD_$(BOARD) -Wall -Werror
 
 PROGS := loader.elf
 OBJECTS := loader.o crt0.o util64.o
@@ -29,7 +29,7 @@ LINKSCRIPT_INPUT := loader.ld
 LINKSCRIPT := $(BUILD_DIR)/link.ld
 
 $(BUILD_DIR)/%.o : src/%.S
-	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
+	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g  -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
 	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -12,14 +12,14 @@ $(error GCC_CPU must be specified)
 endif
 
 TOOLCHAIN := aarch64-none-elf-
-CFLAGS := -std=gnu11 -g3 -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Werror -I$(SEL4_SDK)/include
+CFLAGS := -std=gnu11 -g -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Werror -I$(SEL4_SDK)/include
 
 PROGS := monitor.elf
 OBJECTS := main.o crt0.o debug.o util.o
 LINKSCRIPT := monitor.ld
 
 $(BUILD_DIR)/%.o : src/%.S
-	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g3  -mcpu=$(GCC_CPU)  $< -o $@
+	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g  -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
 	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-pyoxidizer==0.17.0
+pyoxidizer==0.24.0
 mypy==0.910
 black==21.7b0
 flake8==3.9.2

--- a/tests/capfault/Makefile
+++ b/tests/capfault/Makefile
@@ -16,7 +16,7 @@ AS := $(TOOLCHAIN)-as
 CAPFAULT_OBJS := capfault.o
 
 IMAGES := capfault.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(SEL4_SDK)/include -I$(LIBMICROKIT)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(SEL4_SDK)/include -I$(LIBMICROKIT)/include
 LDFLAGS := -L$(LIBMICROKIT) -Tmicrokit.ld
 LIBS := -lmicrokit
 
@@ -27,7 +27,7 @@ all: $(IMAGES)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 %.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 capfault.elf: $(CAPFAULT_OBJS)
 	$(LD) $(LDFLAGS) $(CAPFAULT_OBJS) $(LIBS) -o $@

--- a/tests/overlapping_pages/Makefile
+++ b/tests/overlapping_pages/Makefile
@@ -16,7 +16,7 @@ AS := $(TOOLCHAIN)-as
 OVERLAPPING_PAGES_OBJS := overlapping_pages.o
 
 IMAGES := overlapping_pages.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(SEL4_SDK)/include -I$(LIBMICROKIT)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(SEL4_SDK)/include -I$(LIBMICROKIT)/include
 LDFLAGS := -L$(LIBMICROKIT) -Tmicrokit.ld
 LIBS := -lmicrokit
 
@@ -27,7 +27,7 @@ all: $(IMAGES)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 %.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 overlapping_pages.elf: $(OVERLAPPING_PAGES_OBJS)
 	$(LD) $(LDFLAGS) $(OVERLAPPING_PAGES_OBJS) $(LIBS) -o $@

--- a/tests/simplemrs/Makefile
+++ b/tests/simplemrs/Makefile
@@ -16,7 +16,7 @@ AS := $(TOOLCHAIN)-as
 SIMPLEMRS_OBJS := simplemrs.o
 
 IMAGES := simplemrs.elf
-CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g3 -O3 -Wall  -Wno-unused-function -Werror -I$(SEL4_SDK)/include -I$(LIBMICROKIT)/include
+CFLAGS := -mcpu=$(CPU) -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(SEL4_SDK)/include -I$(LIBMICROKIT)/include
 LDFLAGS := -L$(LIBMICROKIT) -Tmicrokit.ld
 LIBS := -lmicrokit
 
@@ -27,7 +27,7 @@ all: $(IMAGES)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 %.o: %.s Makefile
-	$(AS) -g3 -mcpu=$(CPU) $< -o $@
+	$(AS) -g -mcpu=$(CPU) $< -o $@
 
 simplemrs.elf: $(SIMPLEMRS_OBJS)
 	$(LD) $(LDFLAGS) $(SIMPLEMRS_OBJS) $(LIBS) -o $@


### PR DESCRIPTION
It would be sad to force macOS users to have to dual boot or use a Docker container in order to use the Microkit SDK. These patches add macOS support to the Microkit SDK and have received internal use at TS for a while now so I think it's fair to say that the macOS support will be stable.

Couple of things left to do:
- [x] Update README to mention macOS is supported too
- [x] Use the same toolchain version across macOS/Linux (ARM only supplies macOS ARM64 toolchains for GCC 12.2 and above so we should make it consistent across environments when building Microkit).
- [x] I have noticed the ARM GCC toolchains are *really* slow to download sometimes, causing timeouts in the CI. I've been annoyed by this to the point that I just use my own web server on my fork of Microkit but it's probably not a good idea to do that here. Not sure what to do about this, let's start with using ARM's website for a start and see what happens (ideally we'd have backups of these toolchains etc anyways).