### PR TITLE
Downgrade Pyoxidizer from 0.24.0 to 0.23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-pyoxidizer==0.24.0
+pyoxidizer==0.23.0
 mypy==0.910
 black==21.7b0
 flake8==3.9.2


### PR DESCRIPTION
Unfortunately it seems that multiple people in the community are struggling to build from source after we upgraded to the latest version of Pyoxidizer (same issue as https://github.com/seL4/microkit/issues/37)

This seems to be a known issue in the project
https://github.com/indygreg/PyOxidizer/issues/673.

The nature of this problem comes from our over-reliance on 3rd-party dependencies to package the Microkit tool. We will most likely encounter further issues as we are compiling an interpreted language.

However, even if we were to switch to a compile time langauge (e.g Rust) we would still have problems as the Rust compiler is not isolated.