### PR TITLE
ci: update GitHub actions

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Microkit repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout seL4 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             repository: seL4/seL4
             ref: microkit
@@ -51,9 +51,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout Microkit repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout seL4 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             repository: seL4/seL4
             ref: microkit
@@ -76,9 +76,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout Microkit repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout seL4 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             repository: seL4/seL4
             ref: microkit


### PR DESCRIPTION
NodeJS 16 is deprecated so we have to upgrade
the GitHub actions that depend on it.