### PR TITLE
Update to latest seL4

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Please clone seL4 from:
 
 The correct branch to use is `microkit`.
 
-Testing has been performed using commit `7008430d4432c71a74b2a1da0afae58f7a8658df`.
+Testing has been performed using commit `57975d485397ce1744f7163644dd530560d0b7ec`.
 
 ## Building the SDK
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ ply==3.11
 Jinja2==3.0.3
 PyYAML==6.0
 pyfdt==0.3
+lxml==5.2.1


### PR DESCRIPTION
Main motivation is so the rust-sel4 project can depend on mainline Microkit (some patches to seL4 required by the project weren't in the branch Microkit uses).
