### PR TITLE
libmicrokit: remove dependency on toolchain headers

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -354,12 +354,12 @@ Additionally, if the protection domain provides a protected procedure it must al
 
     microkit_msginfo microkit_ppcall(microkit_channel ch, microkit_msginfo msginfo);
     void microkit_notify(microkit_channel ch);
-    microkit_msginfo microkit_msginfo_new(uint64_t label, uint16_t count);
-    uint64_t microkit_msginfo_get_label(microkit_msginfo msginfo);
-    uint64_t microkit_msginfo_get_count(microkit_msginfo msginfo);
+    microkit_msginfo microkit_msginfo_new(seL4_Word label, seL4_Uint16 count);
+    seL4_Word microkit_msginfo_get_label(microkit_msginfo msginfo);
+    seL4_Word microkit_msginfo_get_count(microkit_msginfo msginfo);
     void microkit_irq_ack(microkit_channel ch);
-    void microkit_mr_set(uint8_t mr, uint64_t value);
-    uint64_t microkit_mr_get(uint8_t mr);
+    void microkit_mr_set(seL4_Uint8 mr, seL4_Word value);
+    seL4_Word microkit_mr_get(seL4_Uint8 mr);
 
 
 ## `void init(void)`

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -8,9 +8,6 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stdbool.h>
-
 #define __thread
 #include <sel4/sel4.h>
 
@@ -31,7 +28,7 @@ microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo);
 
 extern char microkit_name[16];
 /* These next three variables are so our PDs can combine a signal with the next Recv syscall */
-extern bool have_signal;
+extern seL4_Bool have_signal;
 extern seL4_CPtr signal;
 extern seL4_MessageInfo_t signal_msg;
 
@@ -60,27 +57,27 @@ static inline microkit_msginfo microkit_ppcall(microkit_channel ch, microkit_msg
     return seL4_Call(BASE_ENDPOINT_CAP + ch, msginfo);
 }
 
-static inline microkit_msginfo microkit_msginfo_new(uint64_t label, uint16_t count)
+static inline microkit_msginfo microkit_msginfo_new(seL4_Word label, seL4_Uint16 count)
 {
     return seL4_MessageInfo_new(label, 0, 0, count);
 }
 
-static inline uint64_t microkit_msginfo_get_label(microkit_msginfo msginfo)
+static inline seL4_Word microkit_msginfo_get_label(microkit_msginfo msginfo)
 {
     return seL4_MessageInfo_get_label(msginfo);
 }
 
-static inline uint64_t microkit_msginfo_get_count(microkit_msginfo msginfo)
+static inline seL4_Word microkit_msginfo_get_count(microkit_msginfo msginfo)
 {
     return seL4_MessageInfo_get_length(msginfo);
 }
 
-static void microkit_mr_set(uint8_t mr, uint64_t value)
+static void microkit_mr_set(seL4_Uint8 mr, seL4_Word value)
 {
     seL4_SetMR(mr, value);
 }
 
-static uint64_t microkit_mr_get(uint8_t mr)
+static seL4_Word microkit_mr_get(seL4_Uint8 mr)
 {
     return seL4_GetMR(mr);
 }

--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -21,7 +21,9 @@ char _stack[4096]  __attribute__((__aligned__(16)));
 
 bool passive;
 char microkit_name[16];
-bool have_signal = false;
+/* We use seL4 typedefs as this variable is exposed to the libmicrokit header
+ * and we do not want to rely on compiler built-in defines. */
+seL4_Bool have_signal = seL4_False;
 seL4_CPtr signal;
 seL4_MessageInfo_t signal_msg;
 
@@ -58,7 +60,7 @@ static void handler_loop(void)
             tag = seL4_ReplyRecv(INPUT_CAP, reply_tag, &badge, REPLY_CAP);
         } else if (have_signal) {
             tag = seL4_NBSendRecv(signal, signal_msg, INPUT_CAP, &badge, REPLY_CAP);
-            have_signal = false;
+            have_signal = seL4_False;
         } else {
             tag = seL4_Recv(INPUT_CAP, &badge, REPLY_CAP);
         }
@@ -94,7 +96,7 @@ void main(void)
      * We delay this signal so we are ready waiting on a recv() syscall
      */
     if (passive) {
-        have_signal = true;
+        have_signal = seL4_True;
         signal_msg = seL4_MessageInfo_new(0, 0, 0, 1);
         seL4_SetMR(0, 0);
         signal = (MONITOR_EP);


### PR DESCRIPTION
The headers included in microkit.h depend on the compiler and toolchain, it is beneficial to avoid this if possible as they may not be provided at all depending on the C toolchain or contain subtle differences to what we expect.

Closes https://github.com/seL4/microkit/issues/124.