### PR TITLE
Remove mention of musl dependency

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -35,7 +35,7 @@ jobs:
           sudo apt install \
             cmake pandoc device-tree-compiler ninja-build \
             texlive-fonts-recommended texlive-formats-extra libxml2-utils \
-            python3.9 python3-pip python3.9-venv musl-tools \
+            python3.9 python3-pip python3.9-venv \
             qemu-system-arm \
       - name: Install AArch64 GCC toolchain
         run: |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Please file an issue if additional packages are required.
 * make
 * python3.9
 * python3.9-venv
-* musl-1.2.2 (only when targeting Linux)
 * cmake
 * ninja-build
 * ARM GCC compiler for none-elf; version 12.2.1 20221205
@@ -63,7 +62,6 @@ On a Debian-like system you can do:
         pandoc texlive-latex-base texlive-latex-recommended \
         texlive-fonts-recommended texlive-fonts-extra \
         python3.9 python3.9-venv \
-        musl-dev musl-tools \
         qemu-system-arm
 
 If you do not have Python 3.9 available, you can get it via the


### PR DESCRIPTION
Dependency on musl is thankfully gone now! While we still use the *-musl targets for the tool that is now rewritten in Rust instead of using Python/pyoxidizer, it is not dependent on the musl-gcc toolchain.