### PR TITLE
tool: fix logic bugs

### DIFF
--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -146,8 +146,9 @@ impl DisjointMemoryRegion {
     pub fn insert_region(&mut self, base: u64, end: u64) {
         let mut insert_idx = self.regions.len();
         for (idx, region) in self.regions.iter().enumerate() {
-            if end >= region.base {
+            if end < region.base {
                 insert_idx = idx;
+                break;
             }
         }
         // FIXME: Should extend here if adjacent rather than

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -627,6 +627,7 @@ fn emulate_kernel_boot(kernel_config: &Config, kernel_elf: &ElfFile, initial_tas
         let start = util::round_down(region.end - initial_objects_size, 1 << initial_objects_align);
         if start >= region.base {
             region_to_remove = Some(start);
+            break;
         }
     }
     if let Some(start) = region_to_remove {


### PR DESCRIPTION
Mistakes from the rewrite of the tool.

This should get the ZCU102 working again, which I forgot to test before merging the rewritten tool.