### PR TITLE
chore: apply clippy lints on Rust code

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,3 +32,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/style@master
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    # Make sure CI fails on all warnings, including Clippy lints
+    env:
+      RUSTFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run Clippy
+        run: cd tool/microkit && cargo clippy --all-targets --all-features

--- a/tool/microkit/src/elf.rs
+++ b/tool/microkit/src/elf.rs
@@ -231,7 +231,7 @@ impl ElfFile {
             return Err(format!("ELF '{}': unable to find string table section", path.display()));
         }
 
-        assert!(!symtab_shent.is_none());
+        assert!(symtab_shent.is_some());
         if symtab_shent.is_none() {
             return Err(format!("ELF '{}': unable to find symbol table section", path.display()));
         }
@@ -305,7 +305,7 @@ impl ElfFile {
             }
         }
 
-        return None;
+        None
     }
 
     fn get_string(strtab: &[u8], idx: usize) -> Result<&str, String> {

--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -123,21 +123,12 @@ impl MemoryRegion {
     }
 }
 
+#[derive(Default)]
 pub struct DisjointMemoryRegion {
     pub regions: Vec<MemoryRegion>,
 }
 
-impl Default for DisjointMemoryRegion {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl DisjointMemoryRegion {
-    pub fn new() -> DisjointMemoryRegion {
-        DisjointMemoryRegion { regions: Vec::new() }
-    }
-
     fn check(&self) {
         // Ensure that regions are sorted and non-overlapping
         let mut last_end: Option<u64> = None;

--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -127,6 +127,12 @@ pub struct DisjointMemoryRegion {
     pub regions: Vec<MemoryRegion>,
 }
 
+impl Default for DisjointMemoryRegion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DisjointMemoryRegion {
     pub fn new() -> DisjointMemoryRegion {
         DisjointMemoryRegion { regions: Vec::new() }
@@ -218,7 +224,7 @@ impl DisjointMemoryRegion {
         match region_to_remove {
             Some(region) => {
                 self.remove_region(region.base, region.base + size);
-                return region.base;
+                region.base
             },
             None => panic!("Unable to allocate {} bytes", size)
         }
@@ -287,7 +293,7 @@ impl ObjectAllocator {
             untyped.push(UntypedAllocator::new(*ut, 0, vec![]));
         }
 
-        ObjectAllocator { allocation_idx: 0, untyped: untyped }
+        ObjectAllocator { allocation_idx: 0, untyped }
     }
 
     pub fn alloc(&mut self, size: u64) -> KernelAllocation {

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -274,6 +274,7 @@ impl<'a> Loader<'a> {
 
         let mut boot_lvl1_lower: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         for i in 0..512 {
+            #[allow(clippy::identity_op)] // keep the (0 << 2) for clarity
             let pt_entry: u64 =
                 ((i as u64) << AARCH64_1GB_BLOCK_BITS) |
                 (1 << 10) | // access flag

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -288,14 +288,14 @@ impl<'a> Loader<'a> {
         let mut boot_lvl0_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let pt_entry = (boot_lvl1_upper_addr | 3).to_le_bytes();
-            let idx = Aarch64::lvl0_index(first_vaddr) as usize;
+            let idx = Aarch64::lvl0_index(first_vaddr);
             boot_lvl0_upper[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry);
         }
 
         let mut boot_lvl1_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let pt_entry = (boot_lvl2_upper_addr | 3).to_le_bytes();
-            let idx = Aarch64::lvl1_index(first_vaddr) as usize;
+            let idx = Aarch64::lvl1_index(first_vaddr);
             boot_lvl1_upper[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry);
         }
 

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -243,20 +243,20 @@ impl<'a> Loader<'a> {
         let mut loader_buf = BufWriter::new(loader_file);
 
         // First write out all the image data
-        loader_buf.write(self.image.as_slice()).expect("Failed to write image data to loader");
+        loader_buf.write_all(self.image.as_slice()).expect("Failed to write image data to loader");
 
         // Then we write out the loader metadata (known as the 'header')
         let header_bytes = unsafe { struct_to_bytes(&self.header) };
-        loader_buf.write(header_bytes).expect("Failed to write header data to loader");
+        loader_buf.write_all(header_bytes).expect("Failed to write header data to loader");
         // For each region, we need to write out the region metadata as well
         for region in &self.region_metadata {
             let region_metadata_bytes = unsafe { struct_to_bytes(region) };
-            loader_buf.write(region_metadata_bytes).expect("Failed to write region metadata to loader");
+            loader_buf.write_all(region_metadata_bytes).expect("Failed to write region metadata to loader");
         }
 
         // Now we can write out all the region data
         for (_, data) in &self.regions {
-            loader_buf.write(data).expect("Failed to write region data to loader");
+            loader_buf.write_all(data).expect("Failed to write region data to loader");
         }
 
         loader_buf.flush().unwrap();

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -1763,7 +1763,7 @@ fn build_system(kernel_config: &Config,
             // There are no arch-dependent flags to set
             arch_flags: 0,
             // FIXME: we could optimise this since we are only setting the program counter
-            count: regs.len(),
+            count: Aarch64Regs::LEN as u64,
             regs,
         }));
     }

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -507,8 +507,8 @@ fn kernel_boot_mem(kernel_elf: &ElfFile) -> MemoryRegion {
 fn kernel_partial_boot(kernel_config: &Config, kernel_elf: &ElfFile) -> KernelPartialBootInfo {
     // Determine the untyped caps of the system
     // This lets allocations happen correctly.
-    let mut device_memory = DisjointMemoryRegion::new();
-    let mut normal_memory = DisjointMemoryRegion::new();
+    let mut device_memory = DisjointMemoryRegion::default();
+    let mut normal_memory = DisjointMemoryRegion::default();
 
     // Start by allocating the entire physical address space
     // as device memory.
@@ -1752,8 +1752,10 @@ fn build_system(kernel_config: &Config,
 
     // Set TCB registers (we only set the entry point)
     for pd_idx in 0..system.protection_domains.len() {
-        let mut regs = Aarch64Regs::new();
-        regs.pc = pd_elf_files[pd_idx].entry;
+        let regs = Aarch64Regs {
+            pc: pd_elf_files[pd_idx].entry,
+            .. Default::default()
+        };
 
         system_invocations.push(Invocation::new(InvocationArgs::TcbWriteRegisters {
             tcb: tcb_objs[pd_idx].cap_addr,

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -245,7 +245,7 @@ enum InvocationLabel {
     ArmIrqIssueIrqHandlerTrigger = 52,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[allow(dead_code)]
 pub struct Aarch64Regs {
     pub pc: u64,
@@ -286,55 +286,7 @@ pub struct Aarch64Regs {
     pub tpidrro_el0: u64,
 }
 
-impl Default for Aarch64Regs {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Aarch64Regs {
-    // Returns a zero-initialised instance
-    pub fn new() -> Aarch64Regs {
-        Aarch64Regs {
-            pc: 0,
-            sp: 0,
-            spsr: 0,
-            x0: 0,
-            x1: 0,
-            x2: 0,
-            x3: 0,
-            x4: 0,
-            x5: 0,
-            x6: 0,
-            x7: 0,
-            x8: 0,
-            x16: 0,
-            x17: 0,
-            x18: 0,
-            x29: 0,
-            x30: 0,
-            x9: 0,
-            x10: 0,
-            x11: 0,
-            x12: 0,
-            x13: 0,
-            x14: 0,
-            x15: 0,
-            x19: 0,
-            x20: 0,
-            x21: 0,
-            x22: 0,
-            x23: 0,
-            x24: 0,
-            x25: 0,
-            x26: 0,
-            x27: 0,
-            x28: 0,
-            tpidr_el0: 0,
-            tpidrro_el0: 0,
-        }
-    }
-
     pub fn field_names(&self) -> [(&'static str, u64); 36] {
         [
             ("pc", self.pc),

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -150,6 +150,7 @@ pub enum ArmVmAttributes {
 }
 
 impl ArmVmAttributes {
+    #[allow(clippy::should_implement_trait)] // Default::default would return Self, not u64
     pub fn default() -> u64 {
         ArmVmAttributes::Cacheable as u64 | ArmVmAttributes::ParityEnabled as u64
     }
@@ -416,6 +417,7 @@ impl Aarch64Regs {
         ]
     }
 
+    #[allow(clippy::len_without_is_empty)] // this will never be *empty*, bad lint
     /// Just returns the count of registers
     pub const fn len(&self) -> u64 {
         36
@@ -773,7 +775,7 @@ impl InvocationArgs {
 }
 
 #[derive(Clone, Copy)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::large_enum_variant)]
 pub enum InvocationArgs {
     UntypedRetype {
         untyped: u64,

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -370,7 +370,7 @@ impl Aarch64Regs {
     }
 
     /// Number of registers
-    const LEN: u64 = 36;
+    pub const LEN: usize = 36;
 }
 
 pub struct Invocation {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -287,7 +287,7 @@ pub struct Aarch64Regs {
 }
 
 impl Aarch64Regs {
-    pub fn field_names(&self) -> [(&'static str, u64); 36] {
+    pub fn field_names(&self) -> [(&'static str, u64); Self::LEN] {
         [
             ("pc", self.pc),
             ("sp", self.sp),
@@ -328,7 +328,7 @@ impl Aarch64Regs {
         ]
     }
 
-    pub fn as_slice(&self) -> [u64; 36] {
+    pub fn as_slice(&self) -> [u64; Self::LEN] {
         [
             self.pc,
             self.sp,
@@ -369,11 +369,8 @@ impl Aarch64Regs {
         ]
     }
 
-    #[allow(clippy::len_without_is_empty)] // this will never be *empty*, bad lint
-    /// Just returns the count of registers
-    pub const fn len(&self) -> u64 {
-        36
-    }
+    /// Number of registers
+    const LEN: u64 = 36;
 }
 
 pub struct Invocation {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -285,6 +285,12 @@ pub struct Aarch64Regs {
     pub tpidrro_el0: u64,
 }
 
+impl Default for Aarch64Regs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Aarch64Regs {
     // Returns a zero-initialised instance
     pub fn new() -> Aarch64Regs {
@@ -505,7 +511,7 @@ impl Invocation {
     }
 
     fn fmt_field_bool(field_name: &'static str, value: bool) -> String {
-        format!("         {:<20} {}", field_name, value.to_string())
+        format!("         {:<20} {}", field_name, value)
     }
 
     fn fmt_field_cap(field_name: &'static str, cap: u64, cap_lookup: &HashMap<u64, String>) -> String {
@@ -749,11 +755,11 @@ impl InvocationArgs {
                                             vec![vaddr, attr],
                                             vec![vspace]
                                         ),
-            InvocationArgs::PageMap { page, vspace, vaddr, rights, attr } => (page, vec![vaddr, rights as u64, attr], vec![vspace]),
+            InvocationArgs::PageMap { page, vspace, vaddr, rights, attr } => (page, vec![vaddr, rights, attr], vec![vspace]),
             InvocationArgs::CnodeMint { cnode, dest_index, dest_depth, src_root, src_obj, src_depth, rights, badge } =>
                                         (
                                             cnode,
-                                            vec![dest_index, dest_depth, src_obj, src_depth, rights as u64, badge],
+                                            vec![dest_index, dest_depth, src_obj, src_depth, rights, badge],
                                             vec![src_root]
                                         ),
             InvocationArgs::SchedControlConfigureFlags { sched_control, sched_context, budget, period, extra_refills, badge, flags } =>

--- a/tool/microkit/src/sysxml.rs
+++ b/tool/microkit/src/sysxml.rs
@@ -368,7 +368,7 @@ impl SysMemoryRegion {
             None
         };
 
-        if !phys_addr.is_none() && phys_addr.unwrap() % page_size != 0 {
+        if phys_addr.is_some() && phys_addr.unwrap() % page_size != 0 {
             return Err(value_error(xml_sdf, node, "phys_addr is not aligned to the page size".to_string()));
         }
 
@@ -409,7 +409,7 @@ impl Channel {
                     }
 
                     if end_id < 0 {
-                        return Err(value_error(xml_sdf, &child, format!("id must be >= 0")));
+                        return Err(value_error(xml_sdf, &child, "id must be >= 0".to_string()));
                     }
 
                     if let Some(pd_idx) = pds.iter().position(|pd| pd.name == end_pd) {
@@ -535,7 +535,7 @@ pub fn parse(filename: &str, xml: &str, plat_desc: &PlatformDescription) -> Resu
         match child_name {
             "protection_domain" => pds.push(ProtectionDomain::from_xml(&xml_sdf, &child)?),
             "channel" => channel_nodes.push(child),
-            "memory_region" => mrs.push(SysMemoryRegion::from_xml(&xml_sdf, &child, &plat_desc)?),
+            "memory_region" => mrs.push(SysMemoryRegion::from_xml(&xml_sdf, &child, plat_desc)?),
             _ => {
                 let pos = xml_sdf.doc.text_pos_at(child.range().start);
                 return Err(format!("Invalid XML element '{}': {}", child_name, loc_string(&xml_sdf, pos)))
@@ -550,7 +550,7 @@ pub fn parse(filename: &str, xml: &str, plat_desc: &PlatformDescription) -> Resu
     // Now that we have parsed everything in the system description we can validate any
     // global properties (e.g no duplicate PD names etc).
 
-    if pds.len() == 0 {
+    if pds.is_empty() {
         return Err("Error: at least one protection domain must be defined".to_string());
     }
 

--- a/tool/microkit/src/sysxml.rs
+++ b/tool/microkit/src/sysxml.rs
@@ -45,10 +45,9 @@ fn sdf_parse_number(s: &str, node: &roxmltree::Node) -> Result<u64, String> {
     let mut to_parse = s.to_string();
     to_parse.retain(|c| c != '_');
 
-    let (final_str, base) = if to_parse.starts_with("0x") {
-        (&to_parse[2..], 16)
-    } else {
-        (&to_parse[0..], 10)
+    let (final_str, base) = match to_parse.strip_prefix("0x") {
+        Some(stripped) => (stripped, 16),
+        None => (to_parse.as_str(), 10),
     };
 
     match u64::from_str_radix(final_str, base) {
@@ -388,7 +387,7 @@ impl Channel {
     /// It should be noted that this function assumes that `pds` is populated
     /// with all the Protection Domains that could potentially be connected with
     /// the channel.
-    fn from_xml<'a>(xml_sdf: &'a XmlSystemDescription, node: &'a roxmltree::Node, pds: &Vec<ProtectionDomain>) -> Result<Channel, String> {
+    fn from_xml<'a>(xml_sdf: &'a XmlSystemDescription, node: &'a roxmltree::Node, pds: &[ProtectionDomain]) -> Result<Channel, String> {
         check_attributes(xml_sdf, node, &[])?;
 
         let mut ends: Vec<(usize, u64)> = Vec::new();

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -60,7 +60,7 @@ pub fn mask(n: u64) -> u64 {
 }
 
 /// Check that all objects in the list are adjacent
-pub fn objects_adjacent(objects: &Vec<Object>) -> bool {
+pub fn objects_adjacent(objects: &[Object]) -> bool {
     let mut prev_cap_addr = objects[0].cap_addr;
     for obj in &objects[1..] {
         if obj.cap_addr != prev_cap_addr + 1 {

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -22,23 +22,6 @@ pub fn str_to_bool(s: &str) -> Result<bool, &'static str> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
-
-    #[test]
-    fn test_msb() {
-        assert_eq!(msb(37), 5);
-    }
-
-    #[test]
-    fn test_lsb() {
-        assert_eq!(lsb(36), 2);
-        assert_eq!(lsb(37), 0);
-    }
-}
-
 pub const fn kb(n: u64) -> u64 {
     n * 1024
 }
@@ -157,4 +140,21 @@ pub unsafe fn bytes_to_struct<T>(bytes: &[u8]) -> &T {
     assert!(suffix.is_empty());
 
     &body[0]
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_msb() {
+        assert_eq!(msb(37), 5);
+    }
+
+    #[test]
+    fn test_lsb() {
+        assert_eq!(lsb(36), 2);
+        assert_eq!(lsb(37), 0);
+    }
 }

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -126,6 +126,7 @@ pub fn comma_sep_usize(n: usize) -> String {
 
 /// Convert a struct into raw bytes in order to be written to
 /// disk or some other format.
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn struct_to_bytes<T: Sized>(p: &T) -> &[u8] {
     ::core::slice::from_raw_parts(
         (p as *const T) as *const u8,
@@ -133,6 +134,7 @@ pub unsafe fn struct_to_bytes<T: Sized>(p: &T) -> &[u8] {
     )
 }
 
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn bytes_to_struct<T>(bytes: &[u8]) -> &T {
     let (prefix, body, suffix) = unsafe { bytes.align_to::<T>() };
     assert!(prefix.is_empty());


### PR DESCRIPTION
There is a bunch of code flagged by clippy.

- abb7902fca34ffbfc470e204047bbd6ad56d57a4 is a manual fix for a specific problem flagged by clippy
- 731c204d056729dd11f68f8a85327e6553e98037 adds an allow for something `cargo clippy --fix` would remove automatically
- 2115578eaf331ed124460dfa030f7d6f3c3ac62f automatically fixes most of the issues, it contains precisely the result after `cargo clippy --fix`
- fe8ee09cc082f1b8b06794927f09f024173bbb96 fixes the remaining lints by hand. Some of the issues flagged by clippy are non-issues IMHO, hence I added `#[allow(...)]` statements
- 4e464071017623d23be1a044a326f0783508cbb1 adds  a CI check to point out lints violations in an automated fashion 