### PR TITLE
libmicrokit: minor cleanup/improvements

### DIFF
--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -31,9 +31,9 @@ void fault(microkit_channel ch, microkit_msginfo msginfo);
 
 extern char microkit_name[16];
 /* These next three variables are so our PDs can combine a signal with the next Recv syscall */
-extern seL4_Bool have_signal;
-extern seL4_CPtr signal;
-extern seL4_MessageInfo_t signal_msg;
+extern seL4_Bool microkit_have_signal;
+extern seL4_CPtr microkit_signal_cap;
+extern seL4_MessageInfo_t microkit_signal_msg;
 
 /*
  * Output a single character on the debug console.

--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -20,13 +20,15 @@
 
 char _stack[4096]  __attribute__((__aligned__(16)));
 
-bool passive;
+/* All globals are prefixed with microkit_* to avoid clashes with user defined globals. */
+
+bool microkit_passive;
 char microkit_name[16];
 /* We use seL4 typedefs as this variable is exposed to the libmicrokit header
  * and we do not want to rely on compiler built-in defines. */
-seL4_Bool have_signal = seL4_False;
-seL4_CPtr signal;
-seL4_MessageInfo_t signal_msg;
+seL4_Bool microkit_have_signal = seL4_False;
+seL4_CPtr microkit_signal_cap;
+seL4_MessageInfo_t microkit_signal_msg;
 
 extern seL4_IPCBuffer __sel4_ipc_buffer_obj;
 
@@ -63,9 +65,9 @@ static void handler_loop(void)
 
         if (have_reply) {
             tag = seL4_ReplyRecv(INPUT_CAP, reply_tag, &badge, REPLY_CAP);
-        } else if (have_signal) {
-            tag = seL4_NBSendRecv(signal, signal_msg, INPUT_CAP, &badge, REPLY_CAP);
-            have_signal = seL4_False;
+        } else if (microkit_have_signal) {
+            tag = seL4_NBSendRecv(microkit_signal_cap, microkit_signal_msg, INPUT_CAP, &badge, REPLY_CAP);
+            microkit_have_signal = seL4_False;
         } else {
             tag = seL4_Recv(INPUT_CAP, &badge, REPLY_CAP);
         }
@@ -104,11 +106,10 @@ void main(void)
      * it to our notification object.
      * We delay this signal so we are ready waiting on a recv() syscall
      */
-    if (passive) {
-        have_signal = seL4_True;
-        signal_msg = seL4_MessageInfo_new(0, 0, 0, 1);
-        seL4_SetMR(0, 0);
-        signal = (MONITOR_EP);
+    if (microkit_passive) {
+        microkit_have_signal = seL4_True;
+        microkit_signal_msg = seL4_MessageInfo_new(0, 0, 0, 0);
+        microkit_signal_cap = MONITOR_EP;
     }
 
     handler_loop();

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -1835,7 +1835,7 @@ fn build_system(kernel_config: &Config,
         let name = pd.name.as_bytes();
         let name_length = min(name.len(), PD_MAX_NAME_LENGTH);
         elf.write_symbol("microkit_name", &name[..name_length])?;
-        elf.write_symbol("passive", &[pd.passive as u8])?;
+        elf.write_symbol("microkit_passive", &[pd.passive as u8])?;
     }
 
     for (i, pd) in system.protection_domains.iter().enumerate() {


### PR DESCRIPTION
Some variables do genuinely have to be global in libmicrokit and so we make sure they all have a prefix of `microkit_*` to avoid clashing with any user code.

The message registers for passive PD init are not used so we remove those lines.

Closes https://github.com/seL4/microkit/issues/140.