### PR TITLE
tool: fixes for ELF parsing errors

### DIFF
--- a/tool/microkit/src/elf.rs
+++ b/tool/microkit/src/elf.rs
@@ -275,11 +275,11 @@ impl ElfFile {
         Ok(ElfFile { word_size, entry, segments, symbols })
     }
 
-    pub fn find_symbol(&self, variable_name: &str) -> Result<(u64, u64), &'static str> {
+    pub fn find_symbol(&self, variable_name: &str) -> Result<(u64, u64), String> {
         if let Some(sym) = self.symbols.get(variable_name) {
             Ok((sym.value, sym.size))
         } else {
-            Err("variable not found")
+            Err(format!("No symbol named '{variable_name}' not found"))
         }
     }
 


### PR DESCRIPTION
The current code would build up a map of ELF symbols when
first parsing the ELF for quick lookup later on when we
patch/read certain symbols. In this process if we encounter
a symbol that is already in the map, we error and exit.

This patch changes the error to only happen when a symbol we
care about (because we are either writing to it or reading
from it) occurs multiple times.

This lets us parse ELFs even when they have multiple symbols
with the same name and only error if it actually matters.

This issue was brought up by @nspin.