### PR TITLE
Virtualisation support

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -63,6 +63,7 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "tqma8xqp1gb",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "ethernet": Path("example/tqma8xqp1gb/ethernet")
@@ -77,6 +78,7 @@ SUPPORTED_BOARDS = (
             "KernelARMPlatform": "zcu102",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "hello": Path("example/zcu102/hello")
@@ -90,6 +92,7 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "maaxboard",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "hello": Path("example/maaxboard/hello")
@@ -103,6 +106,7 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "imx8mm-evk",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "passive_server": Path("example/imx8mm_evk/passive_server")
@@ -116,6 +120,7 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "imx8mq-evk",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "hello": Path("example/imx8mq_evk/hello")
@@ -129,6 +134,7 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "odroidc2",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "hello": Path("example/odroidc2/hello")
@@ -142,6 +148,7 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "odroidc4",
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "timer": Path("example/odroidc4/timer")
@@ -156,6 +163,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "QEMU_MEMORY": "2048",
+            "KernelArmHypervisorSupport": True,
         },
         examples={
             "hello": Path("example/qemu_virt_aarch64/hello"),
@@ -495,7 +503,8 @@ def main() -> None:
         for config in selected_configs:
             build_sel4(sel4_dir, root_dir, build_dir, board, config)
             loader_defines = [
-                ("LINK_ADDRESS", hex(board.loader_link_address))
+                ("LINK_ADDRESS", hex(board.loader_link_address)),
+                ("PHYSICAL_ADDRESS_BITS", 40)
             ]
             build_elf_component("loader", root_dir, build_dir, board, config, loader_defines)
             build_elf_component("monitor", root_dir, build_dir, board, config, [])

--- a/dev_build.py
+++ b/dev_build.py
@@ -6,7 +6,7 @@
 This is designed to make it easy to build and run examples during development.
 """
 from argparse import ArgumentParser
-from os import environ
+from os import environ, system
 from pathlib import Path
 from shutil import rmtree
 from subprocess import run
@@ -76,6 +76,10 @@ def main():
 
     if not BUILD_DIR.exists():
         BUILD_DIR.mkdir()
+
+    tool_rebuild = f"cd tool/microkit && cargo build && cp target/debug/microkit {release}/bin/microkit"
+    r = system(tool_rebuild)
+    assert r == 0
 
     make_env = environ.copy()
     make_env["BUILD_DIR"] = str(BUILD_DIR.absolute())

--- a/example/qemu_virt_aarch64/hierarchy/restarter.c
+++ b/example/qemu_virt_aarch64/hierarchy/restarter.c
@@ -42,17 +42,20 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
     return microkit_msginfo_new(0, 0);
 }
 
-void fault(microkit_pd id, microkit_msginfo msginfo)
+seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo)
 {
-    microkit_dbg_puts("restarter: received fault message for pd: ");
-    put8(id);
+    microkit_dbg_puts("restarter: received fault message for child pd: ");
+    put8(child);
     microkit_dbg_puts("\n");
     restart_count++;
     if (restart_count < 10) {
-        microkit_pd_restart(id, 0x200000);
+        microkit_pd_restart(child, 0x200000);
         microkit_dbg_puts("restarter: restarted\n");
     } else {
-        microkit_pd_stop(id);
+        microkit_pd_stop(child);
         microkit_dbg_puts("restarter: too many restarts - PD stopped\n");
     }
+
+    /* We explicitly restart the thread so we do not need to 'reply' to the fault. */
+    return seL4_False;
 }

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -12,7 +12,7 @@
 #include <sel4/sel4.h>
 
 typedef unsigned int microkit_channel;
-typedef unsigned int microkit_pd;
+typedef unsigned int microkit_child;
 typedef seL4_MessageInfo_t microkit_msginfo;
 
 #define MONITOR_EP 5
@@ -20,6 +20,8 @@ typedef seL4_MessageInfo_t microkit_msginfo;
 #define BASE_ENDPOINT_CAP 74
 #define BASE_IRQ_CAP 138
 #define BASE_TCB_CAP 202
+#define BASE_VM_TCB_CAP 266
+#define BASE_VCPU_CAP 330
 
 #define MICROKIT_MAX_CHANNELS 62
 
@@ -27,7 +29,7 @@ typedef seL4_MessageInfo_t microkit_msginfo;
 void init(void);
 void notified(microkit_channel ch);
 microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo);
-void fault(microkit_pd pd, microkit_msginfo msginfo);
+seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo);
 
 extern char microkit_name[16];
 /* These next three variables are so our PDs can combine a signal with the next Recv syscall */
@@ -68,7 +70,7 @@ static inline void microkit_irq_ack(microkit_channel ch)
     seL4_IRQHandler_Ack(BASE_IRQ_CAP + ch);
 }
 
-static inline void microkit_pd_restart(microkit_pd pd, seL4_Word entry_point)
+static inline void microkit_pd_restart(microkit_child pd, seL4_Word entry_point)
 {
     seL4_Error err;
     seL4_UserContext ctxt = {0};
@@ -87,7 +89,7 @@ static inline void microkit_pd_restart(microkit_pd pd, seL4_Word entry_point)
     }
 }
 
-static inline void microkit_pd_stop(microkit_pd pd)
+static inline void microkit_pd_stop(microkit_child pd)
 {
     seL4_Error err;
     err = seL4_TCB_Suspend(BASE_TCB_CAP + pd);
@@ -126,3 +128,78 @@ static seL4_Word microkit_mr_get(seL4_Uint8 mr)
 {
     return seL4_GetMR(mr);
 }
+
+/* The following APIs are only available where the kernel is built as a hypervisor. */
+#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT)
+static inline void microkit_vcpu_restart(microkit_child vcpu, seL4_Word entry_point)
+{
+    seL4_Error err;
+    seL4_UserContext ctxt = {0};
+    ctxt.pc = entry_point;
+    err = seL4_TCB_WriteRegisters(
+              BASE_VM_TCB_CAP + vcpu,
+              seL4_True,
+              0, /* No flags */
+              1, /* writing 1 register */
+              &ctxt
+          );
+
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_vm_restart: error writing registers\n");
+        microkit_internal_crash(err);
+    }
+}
+
+static inline void microkit_vcpu_stop(microkit_child vcpu)
+{
+    seL4_Error err;
+    err = seL4_TCB_Suspend(BASE_VM_TCB_CAP + vcpu);
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_vm_stop: error suspending TCB\n");
+        microkit_internal_crash(err);
+    }
+}
+
+static inline void microkit_vcpu_arm_inject_irq(microkit_child vcpu, seL4_Uint16 irq, seL4_Uint8 priority,
+                                                seL4_Uint8 group, seL4_Uint8 index)
+{
+    seL4_Error err;
+    err = seL4_ARM_VCPU_InjectIRQ(BASE_VCPU_CAP + vcpu, irq, priority, group, index);
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_arm_vcpu_inject_irq: error injecting IRQ\n");
+        microkit_internal_crash(err);
+    }
+}
+
+static inline void microkit_vcpu_arm_ack_vppi(microkit_child vcpu, seL4_Word irq)
+{
+    seL4_Error err;
+    err = seL4_ARM_VCPU_AckVPPI(BASE_VCPU_CAP + vcpu, irq);
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_arm_vcpu_ack_vppi: error acking VPPI\n");
+        microkit_internal_crash(err);
+    }
+}
+
+static inline seL4_Word microkit_vcpu_arm_read_reg(microkit_child vcpu, seL4_Word reg)
+{
+    seL4_ARM_VCPU_ReadRegs_t ret;
+    ret = seL4_ARM_VCPU_ReadRegs(BASE_VCPU_CAP + vcpu, reg);
+    if (ret.error != seL4_NoError) {
+        microkit_dbg_puts("microkit_arm_vcpu_read_reg: error reading vCPU register\n");
+        microkit_internal_crash(ret.error);
+    }
+
+    return ret.value;
+}
+
+static inline void microkit_vcpu_arm_write_reg(microkit_child vcpu, seL4_Word reg, seL4_Word value)
+{
+    seL4_Error err;
+    err = seL4_ARM_VCPU_WriteRegs(BASE_VCPU_CAP + vcpu, reg, value);
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_arm_vcpu_write_reg: error writing vCPU register\n");
+        microkit_internal_crash(err);
+    }
+}
+#endif

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -21,7 +21,7 @@ typedef seL4_MessageInfo_t microkit_msginfo;
 #define BASE_IRQ_CAP 138
 #define BASE_TCB_CAP 202
 
-#define MICROKIT_MAX_CHANNELS 63
+#define MICROKIT_MAX_CHANNELS 62
 
 /* User provided functions */
 void init(void);

--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -42,8 +42,9 @@ __attribute__((weak)) microkit_msginfo protected(microkit_channel ch, microkit_m
     return seL4_MessageInfo_new(0, 0, 0, 0);
 }
 
-__attribute__((weak)) void fault(microkit_pd pd, microkit_msginfo msginfo)
+__attribute__((weak)) seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo)
 {
+    return seL4_False;
 }
 
 static void run_init_funcs(void)
@@ -78,7 +79,10 @@ static void handler_loop(void)
         have_reply = false;
 
         if (is_fault) {
-            fault(badge & PD_MASK, tag);
+            seL4_Bool reply_to_fault = fault(badge & PD_MASK, tag, &reply_tag);
+            if (reply_to_fault) {
+                have_reply = true;
+            }
         } else if (is_endpoint) {
             have_reply = true;
             reply_tag = protected(badge & CHANNEL_MASK, tag);

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -19,6 +19,9 @@ ifeq ($(strip $(LINK_ADDRESS)),)
 $(error LINK_ADDRESS must be specified)
 endif
 
+ifeq ($(strip $(PHYSICAL_ADDRESS_BITS)),)
+$(error PHYSICAL_ADDRESS_BITS must be specified)
+endif
 
 TOOLCHAIN := aarch64-none-elf-
 CFLAGS := -std=gnu11 -g -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -DBOARD_$(BOARD) -Wall -Werror -mgeneral-regs-only
@@ -29,7 +32,7 @@ LINKSCRIPT_INPUT := loader.ld
 LINKSCRIPT := $(BUILD_DIR)/link.ld
 
 $(BUILD_DIR)/%.o : src/%.S
-	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g  -mcpu=$(GCC_CPU)  $< -o $@
+	$(TOOLCHAIN)gcc -x assembler-with-cpp -c -g -DPHYSICAL_ADDRESS_BITS=$(PHYSICAL_ADDRESS_BITS) -mcpu=$(GCC_CPU)  $< -o $@
 
 $(BUILD_DIR)/%.o : src/%.s
 	$(TOOLCHAIN)as -g -mcpu=$(GCC_CPU) $< -o $@

--- a/loader/src/util64.S
+++ b/loader/src/util64.S
@@ -60,6 +60,20 @@
 #define TCR_PS_16T        (4 << 16)
 #define TCR_PS_256T       (5 << 16)
 
+#ifndef PHYSICAL_ADDRESS_BITS
+#error "Missing PHYSICAL_ADDRESS_BITS"
+#endif
+
+#if PHYSICAL_ADDRESS_BITS == 40
+#define TCR_PS TCR_PS_1T
+#elif PHYSICAL_ADDRESS_BITS == 44
+#define TCR_PS TCR_PS_16T
+#else
+#error "Unsupported PHYSICAL_ADDRESS_BITS value"
+#endif
+
+#define TCR_EL2_RES1      ((1 << 23) | (1 << 31))
+
 #define TCR_ASID16        (1 << 36)
 
 /* Assembler Macros */
@@ -326,6 +340,65 @@ BEGIN_FUNC(el1_mmu_enable)
 
 END_FUNC(el1_mmu_enable)
 
+BEGIN_FUNC(el2_mmu_enable)
+    stp     x29, x30, [sp, #-16]!
+    mov     x29, sp
+
+    /* Disable caches */
+    bl      flush_dcache
+
+    /* Ensure I-cache, D-cache and mmu are disabled for EL2/Stage1 */
+    disable_mmu sctlr_el2, x8
+
+    /*
+     * Invalidate the local I-cache so that any instructions fetched
+     * speculatively are discarded.
+     */
+    bl      invalidate_icache
+
+    /*
+     *   DEVICE_nGnRnE      000     00000000
+     *   DEVICE_nGnRE       001     00000100
+     *   DEVICE_GRE         010     00001100
+     *   NORMAL_NC          011     01000100
+     *   NORMAL             100     11111111
+     */
+    ldr     x5, =MAIR(0x00, MT_DEVICE_nGnRnE) | \
+                 MAIR(0x04, MT_DEVICE_nGnRE) | \
+                 MAIR(0x0c, MT_DEVICE_GRE) | \
+                 MAIR(0x44, MT_NORMAL_NC) | \
+                 MAIR(0xff, MT_NORMAL)
+    msr     mair_el2, x5
+
+    ldr     x8, =TCR_T0SZ(48) | TCR_IRGN0_WBWC | TCR_ORGN0_WBWC | TCR_SH0_ISH | TCR_TG0_4K | TCR_PS | TCR_EL2_RES1
+    msr     tcr_el2, x8
+    isb
+
+    /* Setup page tables */
+    adrp    x8, boot_lvl0_lower
+    msr     ttbr0_el2, x8
+    isb
+
+    /* invalidate all TLB entries for EL2 */
+    tlbi    alle2is
+    dsb     ish
+    isb
+
+    enable_mmu  sctlr_el2, x8
+
+    /* Invalidate instruction cache */
+    ic  ialluis
+    dsb ish
+    isb
+    /* invalidate all TLB entries for EL2 */
+    tlbi    alle2is
+    dsb     ish
+    isb
+
+    ldp     x29, x30, [sp], #16
+    ret
+
+END_FUNC(el2_mmu_enable)
 
 .extern exception_handler
 .extern exception_register_state

--- a/tool/microkit/Cargo.lock
+++ b/tool/microkit/Cargo.lock
@@ -3,10 +3,36 @@
 version = 3
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "microkit-tool"
 version = "0.1.0"
 dependencies = [
  "roxmltree",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -14,3 +40,57 @@ name = "roxmltree"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -15,3 +15,5 @@ path = "src/main.rs"
 
 [dependencies]
 roxmltree = "0.19.0"
+serde = "1.0.203"
+serde_json = "1.0.117"

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -5,6 +5,7 @@
 //
 
 use crate::sel4::Object;
+use serde_json;
 
 pub fn msb(x: u64) -> u64 {
     64 - x.leading_zeros() as u64 - 1
@@ -14,11 +15,11 @@ pub fn lsb(x: u64) -> u64 {
     x.trailing_zeros() as u64
 }
 
-pub fn str_to_bool(s: &str) -> Result<bool, &'static str> {
+pub fn str_to_bool(s: &str) -> Option<bool> {
     match s {
-        "true" => Ok(true),
-        "false" => Ok(false),
-        _ => Err("invalid boolean value")
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None
     }
 }
 
@@ -122,6 +123,30 @@ pub fn comma_sep_u64(n: u64) -> String {
 
 pub fn comma_sep_usize(n: usize) -> String {
     comma_sep_u64(n as u64)
+}
+
+pub fn json_str_as_u64(json: &serde_json::Value, field: &'static str) -> Result<u64, String> {
+    match json.get(field) {
+        Some(value) => Ok(
+            value
+            .as_str()
+            .unwrap_or_else(|| panic!("JSON field '{}' is not a string", field))
+            .parse::<u64>()
+            .unwrap_or_else(|_| panic!("JSON field '{}' could not be converted to u64", field))
+        ),
+        None => Err(format!("JSON field '{}' does not exist", field))
+    }
+}
+
+pub fn json_str_as_bool(json: &serde_json::Value, field: &'static str) -> Result<bool, String> {
+    match json.get(field) {
+        Some(value) => Ok(
+            value
+            .as_bool()
+            .unwrap_or_else(|| panic!("JSON field '{}' could not be converted to bool", field))
+        ),
+        None => Err(format!("JSON field '{}' does not exist", field))
+    }
 }
 
 /// Convert a struct into raw bytes in order to be written to

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -15,6 +15,8 @@ const DEFAULT_KERNEL_CONFIG: sel4::Config = sel4::Config {
     init_cnode_bits: 12,
     cap_address_bits: 64,
     fan_out_limit: 256,
+    hypervisor: true,
+    arm_pa_size_bits: 40,
 };
 
 const DEFAULT_PLAT_DESC: sysxml::PlatformDescription = sysxml::PlatformDescription::new(&DEFAULT_KERNEL_CONFIG);


### PR DESCRIPTION
This PR adds support for running seL4 in hypervisor mode as well as
a new 'virtual machine' abstraction.

This commit message says 'initial support' as features such as
multi-vCPU/core support for VMs are not yet implemented. However,
with this patch, we can run guest operating systems such as Linux
on a Microkit system.

Merge checklist:
* [x] Finish manual changes
* [x] Change `fault` entry point to handle replying to fault instead of using a `microkit_fault_reply` API.

Post-merge checklist:
*  [ ] Fault handling in the manual could be specified better than just referring to the seL4 reference manual.
* [ ] ARM virtual IRQ handling API could be better described.
* [ ] Don't hardcode physical address bits in build_sdk.py
* [ ] SDF tests for VMs.