### PR TITLE
Add 'benchmark' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The currently supported configurations are:
 
 * release
 * debug
+* benchmark
 
 ## Supported Boards
 
@@ -193,11 +194,4 @@ For documentation on each supported board see the [manual](https://github.com/se
 
 ## Supported Configurations
 
-## Release
-
-In release configuration the loader, kernel and monitor do *not* perform any direct serial output.
-
-
-## Debug
-
-The debug configuration includes basic print output form the loader, kernel and monitor.
+For documentation on each supported board see the [manual](https://github.com/seL4/microkit/blob/main/docs/manual.md#configurations-config).

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -189,6 +189,15 @@ SUPPORTED_CONFIGS = (
             "KernelVerificationBuild": False
         }
     ),
+    ConfigInfo(
+        name="benchmark",
+        debug=False,
+        kernel_options={
+            "KernelArmExportPMUUser": True,
+            "KernelDebugBuild": False,
+            "KernelBenchmarks": "track_utilisation"
+        },
+    ),
 )
 
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -313,8 +313,8 @@ handler via the `fault` entry point. It is then up to the parent to decide how t
 Microkit is distributed as a software development kit (SDK).
 
 The SDK includes support for one or more *boards*.
-Two *configurations* are supported for each board: *debug* and *release*.
-The *debug* configuration includes a debug build of the seL4 kernel to allow console debug output using the kernel's UART driver.
+Three *configurations* are supported for each board: *debug*, *release*, and *benchmark*.
+See [the Configurations section](#config) for more details.
 
 The SDK contains:
 
@@ -336,6 +336,23 @@ The user is free to build their system using whatever build system is deemed mos
 The Microkit tool should be invoked by the system build process to transform a system description (and any referenced program images) into an image file which can be loaded by the target board's bootloader.
 
 The ELF files provided as program images should be standard ELF files and have been linked against the provided libmicrokit.
+
+## Configurations {#config}
+
+## Debug
+
+The *debug* configuration includes a debug build of the seL4 kernel to allow console debug output using the kernel's UART driver.
+
+## Release
+
+The *release* configuration is a release build of the seL4 kernel and is intended for production builds. The loader, monitor, and
+kernel do *not* perform any serial output.
+
+## Benchmark
+
+The *benchmark* configuration uses a build of the seL4 kernel that exports the hardware's performance monitoring unit (PMU) to PDs.
+The kernel also tracks information about CPU utilisation. This benchmark configuration exists due a limitation of the seL4 kernel
+and is intended to be removed once [RFC-16 is implemented](https://github.com/seL4/rfcs/pull/22).
 
 ## System Requirements
 

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -16,6 +16,8 @@ typedef unsigned int microkit_child;
 typedef seL4_MessageInfo_t microkit_msginfo;
 
 #define MONITOR_EP 5
+/* Only valid in the 'benchmark' configuration */
+#define TCB_CAP 6
 #define BASE_OUTPUT_NOTIFICATION_CAP 10
 #define BASE_ENDPOINT_CAP 74
 #define BASE_IRQ_CAP 138

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -17,6 +17,7 @@ const DEFAULT_KERNEL_CONFIG: sel4::Config = sel4::Config {
     fan_out_limit: 256,
     hypervisor: true,
     arm_pa_size_bits: 40,
+    benchmark: false,
 };
 
 const DEFAULT_PLAT_DESC: sdf::PlatformDescription =


### PR DESCRIPTION
This patch adds a new configuration for each platform called 'benchmark'.

The purpose of this is to enable Microkit systems to leverage the benchmark configuration of seL4 that tracks things like kernel entries and CPU utilisation. This also exports the PMU to user-space.

This is not ideal, which is why [RFC-16](https://github.com/seL4/rfcs/pull/22) exists. However, we need to be able to do benchmarking for projects like the seL4 Device Driver Framework in the meantime. It may take a while to get the RFC approved and implemented which is why we are adding this 'temporary' configuration.

[RFC-16]: https://sel4.atlassian.net/browse/RFC-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ