### PR TITLE
tool: add rust-toolchain.toml

### DIFF
--- a/tool/microkit/rust-toolchain.toml
+++ b/tool/microkit/rust-toolchain.toml
@@ -1,0 +1,10 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+[toolchain]
+channel = "1.79.0"
+components = [ "rustfmt" ]
+targets = [ "x86_64-unknown-linux-musl", "x86_64-apple-darwin", "aarch64-apple-darwin" ]


### PR DESCRIPTION
The benefit of a `rust-toolchain.toml` would be enabling anyone building the Microkit SDK to know that they are building it with the same toolchain that upstream used for development and testing.