### PR TITLE
Export ARM architectural timer for QEMU virt AArch64

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -164,6 +164,8 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "QEMU_MEMORY": "2048",
             "KernelArmHypervisorSupport": True,
+            "KernelArmExportPCNTUser": True,
+            "KernelArmExportPTMRUser": True,
         },
         examples={
             "hello": Path("example/qemu_virt_aarch64/hello"),


### PR DESCRIPTION
The QEMU virt platform does not have a timer and so the only
way to get a timer driver working is to use the architectural
timer.

Exporting the architectural timer to user-space can be problematic
as it means any user-space program can access it, including ones
you may not trust. However, as this platform is only intended for
development purposes, this is not an issue.
