### PR TITLE
chore: remove all unsafe

### DIFF
--- a/tool/microkit/Cargo.lock
+++ b/tool/microkit/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +21,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "serde_json",
+ "zerocopy",
 ]
 
 [[package]]
@@ -94,3 +101,24 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -17,3 +17,4 @@ path = "src/main.rs"
 roxmltree = "0.19.0"
 serde = "1.0.203"
 serde_json = "1.0.117"
+zerocopy = { version = "0.7.35", features = ["derive"] }

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -156,23 +156,6 @@ pub fn json_str_as_bool(json: &serde_json::Value, field: &'static str) -> Result
     }
 }
 
-/// Convert a struct into raw bytes in order to be written to
-/// disk or some other format.
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn struct_to_bytes<T: Sized>(p: &T) -> &[u8] {
-    ::core::slice::from_raw_parts((p as *const T) as *const u8, ::core::mem::size_of::<T>())
-}
-
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn bytes_to_struct<T>(bytes: &[u8]) -> &T {
-    let (prefix, body, suffix) = unsafe { bytes.align_to::<T>() };
-    assert!(prefix.is_empty());
-    assert!(body.len() == 1);
-    assert!(suffix.is_empty());
-
-    &body[0]
-}
-
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.


### PR DESCRIPTION
This commit removes all unsafe (entirely related to transmuting) from the code. Instead, Google's zerocopy crate is used to do the transmuting. Being widely used and thoroughly vetted, it is less likely to cause hidden soundness issues.

The impact to the dependencies is minimal, i. e. the only extra crates added to the `Cargo.lock` are `byteorder`, `zerocopy` and `zerocopy-derive`.