### PR TITLE
loader: do not print logs on non-debug mode

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -513,9 +513,11 @@ def main() -> None:
     for board in selected_boards:
         for config in selected_configs:
             build_sel4(sel4_dir, root_dir, build_dir, board, config)
+            loader_printing = 1 if config.name == "debug" else 0
             loader_defines = [
                 ("LINK_ADDRESS", hex(board.loader_link_address)),
-                ("PHYSICAL_ADDRESS_BITS", 40)
+                ("PHYSICAL_ADDRESS_BITS", 40),
+                ("PRINTING", loader_printing)
             ]
             build_elf_component("loader", root_dir, build_dir, board, config, loader_defines)
             build_elf_component("monitor", root_dir, build_dir, board, config, [])

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -23,8 +23,12 @@ ifeq ($(strip $(PHYSICAL_ADDRESS_BITS)),)
 $(error PHYSICAL_ADDRESS_BITS must be specified)
 endif
 
+ifeq ($(strip $(PRINTING)),)
+$(error PRINTING must be specified)
+endif
+
 TOOLCHAIN := aarch64-none-elf-
-CFLAGS := -std=gnu11 -g -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -DBOARD_$(BOARD) -Wall -Werror -mgeneral-regs-only
+CFLAGS := -std=gnu11 -g -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -DPRINTING=$(PRINTING) -DBOARD_$(BOARD) -Wno-unused-function -Wall -Werror -mgeneral-regs-only
 
 PROGS := loader.elf
 OBJECTS := loader.o crt0.o util64.o

--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -213,10 +213,12 @@ static void putc(uint8_t ch)
 
 static void puts(const char *s)
 {
+#if PRINTING
     while (*s) {
         putc(*s);
         s++;
     }
+#endif
 }
 
 static char hexchar(unsigned int v)


### PR DESCRIPTION
The manual says that the loader should not print on release mode, so this patch just makes that true.