### PR TITLE
libmicrokit: add 'deferred' API

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -421,6 +421,8 @@ If the protection domain has children it must also implement:
     seL4_Word microkit_msginfo_get_label(microkit_msginfo msginfo);
     seL4_Word microkit_msginfo_get_count(microkit_msginfo msginfo);
     void microkit_irq_ack(microkit_channel ch);
+    void microkit_deferred_notify(microkit_channel ch);
+    void microkit_deferred_irq_ack(microkit_channel ch);
     void microkit_pd_restart(microkit_child pd, seL4_Word entry_point);
     void microkit_pd_stop(microkit_child pd);
     void microkit_mr_set(seL4_Uint8 mr, seL4_Word value);
@@ -510,6 +512,28 @@ Channel identifiers are specified in the system configuration.
 ## `void microkit_irq_ack(microkit_channel ch)`
 
 Acknowledge the interrupt identified by the specified channel.
+
+## `void microkit_deferred_notify(microkit_channel ch)`
+
+The same as `microkit_notify` but will instead not actually perform the notify until
+the entry point where `microkit_deferred_notify` was called returns.
+
+It is important to note that only a single 'deferred' API call can be made within the
+same entry point.
+
+The purpose of this API is for performance critical code as this API saves
+a kernel system call.
+
+## `void microkit_deferred_irq_ack(microkit_channel ch)`
+
+The same as `microkit_irq_ack` but will instead not actually perform the IRQ acknowledge
+until the entry point where `microkit_deferred_irq_ack` was called returns.
+
+It is important to note that only a single 'deferred' API call can be made within the
+same entry point.
+
+The purpose of this API is for performance critical code as this API saves
+a kernel system call.
 
 ## `void microkit_pd_restart(microkit_child pd, uintptr_t entry_point)`
 

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -205,3 +205,17 @@ static inline void microkit_vcpu_arm_write_reg(microkit_child vcpu, seL4_Word re
     }
 }
 #endif
+
+static inline void microkit_deferred_notify(microkit_channel ch)
+{
+    microkit_have_signal = seL4_True;
+    microkit_signal_msg = seL4_MessageInfo_new(0, 0, 0, 0);
+    microkit_signal_cap = (BASE_OUTPUT_NOTIFICATION_CAP + ch);
+}
+
+static inline void microkit_deferred_irq_ack(microkit_channel ch)
+{
+    microkit_have_signal = seL4_True;
+    microkit_signal_msg = seL4_MessageInfo_new(IRQAckIRQ, 0, 0, 0);
+    microkit_signal_cap = (BASE_IRQ_CAP + ch);
+}


### PR DESCRIPTION
This patch adds two new libmicrokit APIs:
* microkit_deferred_notify
* microkit_deferred_irq_ack

The motivation for this is that the normal versions of these
APIs (e.g microkit_irq_ack) do a system call, and then when you
return from the entry point, another system call is done to wait
on further events.

In the case of `microkit_deferred_irq_ack`, the libmicrokit event
handler will both ack an IRQ and wait for further events in a single
system call.

In the case of `microkit_deferred_notify`, the libmicrokit event
handler will both notify a PD and wait for further events in a single
system call.

In highly performance critical code where there are a lot of events
happening, calling these APIs can significantly
increase performance.
