### PR TITLE
Fix benchmark config to track utilisation

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -251,6 +251,7 @@ SUPPORTED_CONFIGS = (
         kernel_options={
             "KernelArmExportPMUUser": True,
             "KernelDebugBuild": False,
+            "KernelVerificationBuild": False,
             "KernelBenchmarks": "track_utilisation"
         },
     ),


### PR DESCRIPTION
Need to add `KernelVerificationBuild` in order to enable utilisation tracking in the kernel.