### PR TITLE
tool: performance improvements

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -520,6 +520,7 @@ def main() -> None:
     parser.add_argument("--boards", metavar="BOARDS", help="Comma-separated list of boards to support. When absent, all boards are supported.")
     parser.add_argument("--configs", metavar="CONFIGS", help="Comma-separated list of configurations to support. When absent, all configurations are supported.")
     parser.add_argument("--skip-tool", action="store_true", help="Tool will not be built")
+    parser.add_argument("--skip-sel4", action="store_true", help="seL4 will not be built")
     parser.add_argument("--skip-docs", action="store_true", help="Docs will not be built")
     parser.add_argument("--skip-tar", action="store_true", help="SDK and source tarballs will not be built")
 
@@ -597,7 +598,8 @@ def main() -> None:
     build_dir = Path("build")
     for board in selected_boards:
         for config in selected_configs:
-            sel4_gen_config = build_sel4(sel4_dir, root_dir, build_dir, board, config)
+            if not args.skip_sel4:
+                sel4_gen_config = build_sel4(sel4_dir, root_dir, build_dir, board, config)
             loader_printing = 1 if config.name == "debug" else 0
             loader_defines = [
                 ("LINK_ADDRESS", hex(board.loader_link_address)),

--- a/dev_build.py
+++ b/dev_build.py
@@ -77,7 +77,7 @@ def main():
     if not BUILD_DIR.exists():
         BUILD_DIR.mkdir()
 
-    tool_rebuild = f"cd tool/microkit && cargo build && cp target/debug/microkit {release}/bin/microkit"
+    tool_rebuild = f"cd tool/microkit && cargo build --release"
     r = system(tool_rebuild)
     assert r == 0
 
@@ -86,6 +86,7 @@ def main():
     make_env["MICROKIT_BOARD"] = args.board
     make_env["MICROKIT_CONFIG"] = args.config
     make_env["MICROKIT_SDK"] = str(release)
+    make_env["MICROKIT_TOOL"] = Path("tool/microkit/target/release/microkit").absolute()
 
     # Choose the makefile based on the `--example-from-sdk` command line flag
     makefile_directory = (

--- a/tool/microkit/src/elf.rs
+++ b/tool/microkit/src/elf.rs
@@ -201,14 +201,13 @@ impl ElfFile {
 
             let segment_start = phent.offset as usize;
             let segment_end = phent.offset as usize + phent.filesz as usize;
-            let mut segment_data = Vec::from(&bytes[segment_start..segment_end]);
-            // If it is not loadable, we do not have any zeroes to represent
-            let num_zeroes = if phent.type_ != 1 {
-                0
-            } else {
-                (phent.memsz - phent.filesz) as usize
-            };
-            segment_data.resize(segment_data.len() + num_zeroes, 0);
+
+            if phent.type_ != 1 {
+                continue;
+            }
+
+            let mut segment_data = vec![0; phent.memsz as usize];
+            segment_data[..phent.filesz as usize].copy_from_slice(&bytes[segment_start..segment_end]);
 
             let segment = ElfSegment {
                 data: segment_data,

--- a/tool/microkit/src/elf.rs
+++ b/tool/microkit/src/elf.rs
@@ -207,7 +207,8 @@ impl ElfFile {
             }
 
             let mut segment_data = vec![0; phent.memsz as usize];
-            segment_data[..phent.filesz as usize].copy_from_slice(&bytes[segment_start..segment_end]);
+            segment_data[..phent.filesz as usize]
+                .copy_from_slice(&bytes[segment_start..segment_end]);
 
             let segment = ElfSegment {
                 data: segment_data,

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -1439,7 +1439,7 @@ fn build_system(
         }
     }
 
-    // 3.2 Now allocate all the fixed mRs
+    // 3.2 Now allocate all the fixed MRs
 
     // First we need to find all the requested pages and sorted them
     let mut fixed_pages = Vec::new();

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -266,6 +266,19 @@ impl<'a> InitSystem<'a> {
             )
         };
 
+        let space_left = fut.ut.region.end - fut.watermark;
+        if space_left < alloc_size {
+            for ut in &self.device_untyped {
+                let space_left = ut.ut.region.end - ut.watermark;
+                println!("ut [0x{:x}..0x{:x}], space left: 0x{:x}", ut.ut.region.base, ut.ut.region.end, space_left);
+            }
+            panic!(
+                "Error: allocation for physical address {:x} is too large ({:x}) for untyped",
+                phys_address,
+                alloc_size
+            );
+        }
+
         if phys_address < fut.watermark {
             panic!(
                 "Error: physical address {:x} is below watermark",
@@ -1322,6 +1335,8 @@ fn build_system(
             extra_mrs.push(mr);
         }
     }
+
+    assert!(phys_addr_next - (reserved_base + invocation_table_size) == pd_elf_size);
 
     // Here we create a memory region/mapping for the stack for each PD.
     // We allocate the stack at the highest possible virtual address that the

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -1380,9 +1380,10 @@ fn build_system(
     let mut large_page_names = Vec::new();
 
     for pd in &system.protection_domains {
+        let (page_size_human, page_size_label) = util::human_size_strict(PageSize::Small as u64);
         let ipc_buffer_str = format!(
-            "Page({}): IPC Buffer PD={}",
-            util::human_size_strict(PageSize::Small as u64),
+            "Page({} {}): IPC Buffer PD={}",
+            page_size_human, page_size_label,
             pd.name
         );
         small_page_names.push(ipc_buffer_str);
@@ -1393,9 +1394,9 @@ fn build_system(
             continue;
         }
 
-        let page_size_human = util::human_size_strict(mr.page_size as u64);
+        let (page_size_human, page_size_label) = util::human_size_strict(mr.page_size as u64);
         for idx in 0..mr.page_count {
-            let page_str = format!("Page({}): MR={} #{}", page_size_human, mr.name, idx);
+            let page_str = format!("Page({} {}): MR={} #{}", page_size_human, page_size_label, mr.name, idx);
             match mr.page_size as PageSize {
                 PageSize::Small => small_page_names.push(page_str),
                 PageSize::Large => large_page_names.push(page_str),
@@ -1463,7 +1464,8 @@ fn build_system(
             PageSize::Large => ObjectType::LargePage,
         };
 
-        let name = format!("Page({}): MR={} @ {:x}", util::human_size_strict(mr.page_size as u64), mr.name, phys_addr);
+        let (page_size_human, page_size_label) = util::human_size_strict(mr.page_size as u64);
+        let name = format!("Page({} {}): MR={} @ {:x}", page_size_human, page_size_label, mr.name, phys_addr);
         let page = init_system.allocate_fixed_object(phys_addr, obj_type, 1, name);
         mr_pages.get_mut(mr).unwrap().push(page);
     }

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -402,17 +402,16 @@ impl<'a> InitSystem<'a> {
 
         let mut kernel_objects = Vec::new();
         let mut phys_addr = allocation.phys_addr;
-        for idx in 0..count {
-            let cap_slot = base_cap_slot + idx;
+        for (idx, name) in names.into_iter().enumerate() {
+            let cap_slot = base_cap_slot + idx as u64;
             let cap_addr = self.cnode_mask | cap_slot;
-            let name = &names[idx as usize];
             let kernel_object = Object {
                 object_type,
                 cap_addr,
                 phys_addr,
             };
             kernel_objects.push(kernel_object.clone());
-            self.cap_address_names.insert(cap_addr, name.clone());
+            self.cap_address_names.insert(cap_addr, name);
 
             phys_addr += alloc_size;
 

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -270,12 +270,14 @@ impl<'a> InitSystem<'a> {
         if space_left < alloc_size {
             for ut in &self.device_untyped {
                 let space_left = ut.ut.region.end - ut.watermark;
-                println!("ut [0x{:x}..0x{:x}], space left: 0x{:x}", ut.ut.region.base, ut.ut.region.end, space_left);
+                println!(
+                    "ut [0x{:x}..0x{:x}], space left: 0x{:x}",
+                    ut.ut.region.base, ut.ut.region.end, space_left
+                );
             }
             panic!(
                 "Error: allocation for physical address {:x} is too large ({:x}) for untyped",
-                phys_address,
-                alloc_size
+                phys_address, alloc_size
             );
         }
 
@@ -456,7 +458,11 @@ struct BuiltSystem {
     initial_task_phys_region: MemoryRegion,
 }
 
-pub fn pd_write_symbols(pds: &Vec<ProtectionDomain>, pd_elf_files: &mut Vec<ElfFile>, pd_setvar_values: &Vec<Vec<u64>>) -> Result<(), String> {
+pub fn pd_write_symbols(
+    pds: &[ProtectionDomain],
+    pd_elf_files: &mut [ElfFile],
+    pd_setvar_values: &[Vec<u64>],
+) -> Result<(), String> {
     for (i, pd) in pds.iter().enumerate() {
         let elf = &mut pd_elf_files[i];
         let name = pd.name.as_bytes();
@@ -1396,8 +1402,7 @@ fn build_system(
         let (page_size_human, page_size_label) = util::human_size_strict(PageSize::Small as u64);
         let ipc_buffer_str = format!(
             "Page({} {}): IPC Buffer PD={}",
-            page_size_human, page_size_label,
-            pd.name
+            page_size_human, page_size_label, pd.name
         );
         small_page_names.push(ipc_buffer_str);
     }
@@ -1409,7 +1414,10 @@ fn build_system(
 
         let (page_size_human, page_size_label) = util::human_size_strict(mr.page_size as u64);
         for idx in 0..mr.page_count {
-            let page_str = format!("Page({} {}): MR={} #{}", page_size_human, page_size_label, mr.name, idx);
+            let page_str = format!(
+                "Page({} {}): MR={} #{}",
+                page_size_human, page_size_label, mr.name, idx
+            );
             match mr.page_size as PageSize {
                 PageSize::Small => small_page_names.push(page_str),
                 PageSize::Large => large_page_names.push(page_str),
@@ -1443,10 +1451,7 @@ fn build_system(
             PageSize::Small => small_page_objs[idx..idx + mr.page_count as usize].to_vec(),
             PageSize::Large => large_page_objs[idx..idx + mr.page_count as usize].to_vec(),
         };
-        mr_pages.insert(
-            mr,
-            objs
-        );
+        mr_pages.insert(mr, objs);
         match mr.page_size {
             PageSize::Small => page_small_idx += mr.page_count as usize,
             PageSize::Large => page_large_idx += mr.page_count as usize,
@@ -1478,7 +1483,10 @@ fn build_system(
         };
 
         let (page_size_human, page_size_label) = util::human_size_strict(mr.page_size as u64);
-        let name = format!("Page({} {}): MR={} @ {:x}", page_size_human, page_size_label, mr.name, phys_addr);
+        let name = format!(
+            "Page({} {}): MR={} @ {:x}",
+            page_size_human, page_size_label, mr.name, phys_addr
+        );
         let page = init_system.allocate_fixed_object(phys_addr, obj_type, 1, name);
         mr_pages.get_mut(mr).unwrap().push(page);
     }
@@ -3485,7 +3493,11 @@ fn main() -> Result<(), String> {
     monitor_elf.write_symbol("pd_names", &pd_names_bytes)?;
 
     // Write out all the symbols for each PD
-    pd_write_symbols(&system.protection_domains, &mut pd_elf_files, &built_system.pd_setvar_values)?;
+    pd_write_symbols(
+        &system.protection_domains,
+        &mut pd_elf_files,
+        &built_system.pd_setvar_values,
+    )?;
 
     // Generate the report
     let report = match std::fs::File::create(args.report) {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -29,7 +29,6 @@ pub struct BootInfo {
 /// initial task.
 #[derive(Clone)]
 pub struct Object {
-    pub name: String,
     /// Type of kernel object
     pub object_type: ObjectType,
     pub cap_addr: u64,

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -849,7 +849,7 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field("node_depth", node_depth));
                 arg_strs.push(Invocation::fmt_field("node_offset", node_offset));
                 arg_strs.push(Invocation::fmt_field("num_objects", num_objects));
-                (untyped, cap_lookup.get(&untyped).unwrap().as_str())
+                (untyped, cap_lookup.get(&untyped).unwrap())
             }
             InvocationArgs::TcbSetSchedParams {
                 tcb,
@@ -872,7 +872,7 @@ impl Invocation {
                     cap_lookup,
                 ));
                 arg_strs.push(Invocation::fmt_field_cap("fault_ep", fault_ep, cap_lookup));
-                (tcb, cap_lookup.get(&tcb).unwrap().as_str())
+                (tcb, cap_lookup.get(&tcb).unwrap())
             }
             InvocationArgs::TcbSetSpace {
                 tcb,
@@ -895,7 +895,7 @@ impl Invocation {
                     cap_lookup,
                 ));
                 arg_strs.push(Invocation::fmt_field("vspace_root_data", vspace_root_data));
-                (tcb, cap_lookup.get(&tcb).unwrap().as_str())
+                (tcb, cap_lookup.get(&tcb).unwrap())
             }
             InvocationArgs::TcbSetIpcBuffer {
                 tcb,
@@ -908,9 +908,9 @@ impl Invocation {
                     buffer_frame,
                     cap_lookup,
                 ));
-                (tcb, cap_lookup.get(&tcb).unwrap().as_str())
+                (tcb, cap_lookup.get(&tcb).unwrap())
             }
-            InvocationArgs::TcbResume { tcb } => (tcb, cap_lookup.get(&tcb).unwrap().as_str()),
+            InvocationArgs::TcbResume { tcb } => (tcb, cap_lookup.get(&tcb).unwrap()),
             InvocationArgs::TcbWriteRegisters {
                 tcb,
                 resume,
@@ -930,7 +930,7 @@ impl Invocation {
                     arg_strs.push(format!("                              {}", s));
                 }
 
-                (tcb, cap_lookup.get(&tcb).unwrap().as_str())
+                (tcb, cap_lookup.get(&tcb).unwrap())
             }
             InvocationArgs::TcbBindNotification { tcb, notification } => {
                 arg_strs.push(Invocation::fmt_field_cap(
@@ -938,11 +938,11 @@ impl Invocation {
                     notification,
                     cap_lookup,
                 ));
-                (tcb, cap_lookup.get(&tcb).unwrap().as_str())
+                (tcb, cap_lookup.get(&tcb).unwrap())
             }
             InvocationArgs::AsidPoolAssign { asid_pool, vspace } => {
                 arg_strs.push(Invocation::fmt_field_cap("vspace", vspace, cap_lookup));
-                (asid_pool, cap_lookup.get(&asid_pool).unwrap().as_str())
+                (asid_pool, cap_lookup.get(&asid_pool).unwrap())
             }
             InvocationArgs::IrqControlGetTrigger {
                 irq_control,
@@ -961,7 +961,7 @@ impl Invocation {
                 ));
                 arg_strs.push(Invocation::fmt_field("dest_index", dest_index));
                 arg_strs.push(Invocation::fmt_field("dest_depth", dest_depth));
-                (irq_control, cap_lookup.get(&irq_control).unwrap().as_str())
+                (irq_control, cap_lookup.get(&irq_control).unwrap())
             }
             InvocationArgs::IrqHandlerSetNotification {
                 irq_handler,
@@ -972,7 +972,7 @@ impl Invocation {
                     notification,
                     cap_lookup,
                 ));
-                (irq_handler, cap_lookup.get(&irq_handler).unwrap().as_str())
+                (irq_handler, cap_lookup.get(&irq_handler).unwrap())
             }
             InvocationArgs::PageTableMap {
                 page_table,
@@ -983,7 +983,7 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field_cap("vspace", vspace, cap_lookup));
                 arg_strs.push(Invocation::fmt_field_hex("vaddr", vaddr));
                 arg_strs.push(Invocation::fmt_field("attr", attr));
-                (page_table, cap_lookup.get(&page_table).unwrap().as_str())
+                (page_table, cap_lookup.get(&page_table).unwrap())
             }
             InvocationArgs::PageMap {
                 page,
@@ -996,7 +996,7 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field_hex("vaddr", vaddr));
                 arg_strs.push(Invocation::fmt_field("rights", rights));
                 arg_strs.push(Invocation::fmt_field("attr", attr));
-                (page, cap_lookup.get(&page).unwrap().as_str())
+                (page, cap_lookup.get(&page).unwrap())
             }
             InvocationArgs::CnodeCopy {
                 cnode,
@@ -1013,7 +1013,7 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field_cap("src_obj", src_obj, cap_lookup));
                 arg_strs.push(Invocation::fmt_field("src_depth", src_depth));
                 arg_strs.push(Invocation::fmt_field("rights", rights));
-                (cnode, cap_lookup.get(&cnode).unwrap().as_str())
+                (cnode, cap_lookup.get(&cnode).unwrap())
             }
             InvocationArgs::CnodeMint {
                 cnode,
@@ -1032,7 +1032,7 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field("src_depth", src_depth));
                 arg_strs.push(Invocation::fmt_field("rights", rights));
                 arg_strs.push(Invocation::fmt_field("badge", badge));
-                (cnode, cap_lookup.get(&cnode).unwrap().as_str())
+                (cnode, cap_lookup.get(&cnode).unwrap())
             }
             InvocationArgs::SchedControlConfigureFlags {
                 sched_control,
@@ -1053,11 +1053,11 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field("extra_refills", extra_refills));
                 arg_strs.push(Invocation::fmt_field("badge", badge));
                 arg_strs.push(Invocation::fmt_field("flags", flags));
-                (sched_control, "None")
+                (sched_control, &"None".to_string())
             }
             InvocationArgs::ArmVcpuSetTcb { vcpu, tcb } => {
                 arg_strs.push(Invocation::fmt_field_cap("tcb", tcb, cap_lookup));
-                (vcpu, cap_lookup.get(&vcpu).unwrap().as_str())
+                (vcpu, cap_lookup.get(&vcpu).unwrap())
             }
         };
         _ = writeln!(

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -86,7 +86,7 @@ pub fn objects_adjacent(objects: &[Object]) -> bool {
 /// 'strict' means that it must be simply represented.
 ///  Specifically, it must be a multiple of standard power-of-two.
 ///  (e.g. KiB, MiB, GiB, TiB, PiB, EiB)
-pub fn human_size_strict(size: u64) -> String {
+pub fn human_size_strict(size: u64) -> (String, &'static str) {
     for (bits, label) in [
         (60, "EiB"),
         (50, "PiB"),
@@ -111,7 +111,7 @@ pub fn human_size_strict(size: u64) -> String {
             } else {
                 count = size;
             }
-            return format!("{} {}", comma_sep_u64(count), label);
+            return (comma_sep_u64(count), label);
         }
     }
 


### PR DESCRIPTION
This PR implements a number of performance improvements to make sure that building a Microkit system feels instantaneous, even for larger systems.

Most of the changes decrease the two main bottlenecks, ELF parsing and dynamic memory allocation (aka `.clone` in Rust).

This PR significantly decreases the performance and memory usage of the tool.

Below is performance numbers for a hello world program (top is after, bottom is before):
```
Benchmark 1 (1530 runs): /home/ivanv/ts/microkit/release/microkit-sdk-1.3.0/bin/microkit example/qemu_virt_aarch64/hello/hello.system --search-path /home/ivanv/ts/microkit/tmp_build --board qemu_virt_aarch64 --config debug -o /home/ivanv/ts/microkit/tmp_build/loader.img -r /home/ivanv/ts/microkit/tmp_build/report.txt
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          3.23ms ±  227us    2.94ms … 10.4ms         62 ( 4%)        0%
  peak_rss           2.62MB ± 31.3KB    2.46MB … 2.62MB         58 ( 4%)        0%
  cpu_cycles         3.15M  ±  136K      277K  … 3.98M          49 ( 3%)        0%
  instructions       3.93M  ±  159K      241K  … 3.94M          32 ( 2%)        0%
  cache_references   18.5K  ± 1.40K     2.36K  … 27.6K         167 (11%)        0%
  cache_misses       1.89K  ± 1.23K       46   … 9.64K           2 ( 0%)        0%
  branch_misses      25.8K  ± 1.04K     2.76K  … 28.6K          85 ( 6%)        0%
Benchmark 2 (340 runs): /tmp/microkit/release/microkit-sdk-1.3.0/bin/microkit example/qemu_virt_aarch64/hello/hello.system --search-path /tmp/microkit/tmp_build --board qemu_virt_aarch64 --config debug -o /tmp/microkit/tmp_build/loader.img -r /tmp/microkit/tmp_build/report.txt
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          14.7ms ±  785us    13.2ms … 16.6ms          0 ( 0%)        +355.4% ±  1.4%
  peak_rss           7.18MB ± 73.6KB    6.88MB … 7.37MB         64 (19%)        +174.4% ±  0.2%
  cpu_cycles         55.4M  ± 3.83M     26.5M  … 64.1M           2 ( 1%)        +1658.4% ±  6.1%
  instructions        164M  ± 5.08M     77.1M  …  165M           9 ( 3%)        +4079.0% ±  6.5%
  cache_references   58.5K  ± 2.89K     41.4K  … 75.3K          26 ( 8%)        +216.9% ±  1.1%
  cache_misses       11.2K  ± 3.04K     5.34K  … 30.2K           8 ( 2%)        +495.0% ± 10.7%
  branch_misses      30.6K  ±  654      22.3K  … 33.3K          17 ( 5%)        + 18.6% ±  0.4%
```

Below is performance numbers aiming to represent how long it takes to build a larger system that allocates 256MB of 4K pages and has an ELF size of 80MB:
```
Benchmark 1 (16 runs): /home/ivanv/ts/microkit/release/microkit-sdk-1.3.0/bin/microkit example/qemu_virt_aarch64/hello/hello.system --search-path /home/ivanv/ts/microkit/tmp_build --board qemu_virt_aarch64 --config debug -o /home/ivanv/ts/microkit/tmp_build/loader.img -r /home/ivanv/ts/microkit/tmp_build/report.txt
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           314ms ± 13.0ms     305ms …  346ms          0 ( 0%)        0%
  peak_rss           37.8MB ±  105KB    37.7MB … 38.0MB          0 ( 0%)        0%
  cpu_cycles         1.17G  ± 4.36M     1.16G  … 1.18G           0 ( 0%)        0%
  instructions       1.37G  ± 3.84M     1.35G  … 1.37G           3 (19%)        0%
  cache_references   3.36M  ± 66.0K     3.18M  … 3.45M           1 ( 6%)        0%
  cache_misses        789K  ± 25.2K      752K  …  836K           0 ( 0%)        0%
  branch_misses       499K  ± 24.1K      476K  …  556K           2 (13%)        0%
Benchmark 2 (5 runs): /tmp/microkit/release/microkit-sdk-1.3.0/bin/microkit example/qemu_virt_aarch64/hello/hello.system --search-path /tmp/microkit/tmp_build --board qemu_virt_aarch64 --config debug -o /tmp/microkit/tmp_build/loader.img -r /tmp/microkit/tmp_build/report.txt
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.24s  ± 59.0ms    1.19s  … 1.34s           0 ( 0%)        +293.4% ± 10.0%
  peak_rss            264MB ±  202KB     264MB …  264MB          0 ( 0%)        +597.7% ±  0.4%
  cpu_cycles         5.41G  ±  253M     5.18G  … 5.85G           0 ( 0%)        +364.0% ± 10.7%
  instructions       17.1G  ±  662K     17.1G  … 17.1G           0 ( 0%)        +1149.1% ±  0.3%
  cache_references   13.4M  ± 60.5K     13.3M  … 13.4M           0 ( 0%)        +297.0% ±  2.1%
  cache_misses       2.88M  ± 83.6K     2.75M  … 2.96M           0 ( 0%)        +265.0% ±  6.0%
  branch_misses       706K  ± 90.7K      655K  …  866K           0 ( 0%)        + 41.5% ± 10.1%
```