### PR TITLE
tool: fix bootstrap page table repeat invocation

### DIFF
--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -1225,7 +1225,7 @@ fn build_system(
         InvocationArgs::PageTableMap {
             page_table: 1,
             vspace: 0,
-            vaddr: ObjectType::LargePage as u64,
+            vaddr: ObjectType::LargePage.fixed_size(config).unwrap(),
             attr: 0,
         },
     );


### PR DESCRIPTION
This only revelead itself when building/running a large system with Microkit.

Unfortunately I only ran into this, *after* releasing 1.4.0... :(