### PR TITLE
Enable FPU on QEMU virt RISC-V and Star64

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -210,6 +210,8 @@ SUPPORTED_BOARDS = (
             "KernelPlatform": "qemu-riscv-virt",
             "KernelIsMCS": True,
             "QEMU_MEMORY": "2048",
+            "KernelRiscvExtD": True,
+            "KernelRiscvExtF": True,
         },
         examples={
             "hello": Path("example/qemu_virt_riscv64/hello"),
@@ -223,6 +225,8 @@ SUPPORTED_BOARDS = (
         kernel_options={
             "KernelIsMCS": True,
             "KernelPlatform": "star64",
+            "KernelRiscvExtD": True,
+            "KernelRiscvExtF": True,
         },
         examples={
             "hello": Path("example/star64/hello")


### PR DESCRIPTION
We are compiling libmicrokit with hardware floating extensions which means that user-code must also be compiled with hardware floating extensions.

This meant that before this patch user programs that make use of floating point instructions would crash as the kernel has the FPU disabled.

Something to fix in a separate PR is making the `-march` and `-mabi` of a platform be described for each platform rather than globally which is what it is now.