### PR TITLE
Update PyYAML to 6.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ black==21.7b0
 flake8==3.9.2
 ply==3.11
 Jinja2==3.0.3
-PyYAML==6.0
+PyYAML==6.0.2
 pyfdt==0.3
 lxml==5.2.1


### PR DESCRIPTION
The motivation is that building the dependency from source with Python3.9 does not work with 6.0 but 6.0.2 works fine. The reason this hasn't been an issue before because everyone has been grabbing the dependencies from wheels.