### PR TITLE
tool: minor internal cleanup

### DIFF
--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -232,12 +232,10 @@ impl<'a> InitSystem<'a> {
         &mut self,
         phys_address: u64,
         object_type: ObjectType,
-        count: u64,
         name: String,
     ) -> Object {
         assert!(phys_address >= self.last_fixed_address);
         assert!(object_type.fixed_size(self.config).is_some());
-        assert!(count > 0);
 
         let alloc_size = object_type.fixed_size(self.config).unwrap();
         // Find an untyped that contains the given address, it may be in device
@@ -355,7 +353,7 @@ impl<'a> InitSystem<'a> {
             cap_addr,
             phys_addr: phys_address,
         };
-        self.objects.push(kernel_object.clone());
+        self.objects.push(kernel_object);
         self.cap_address_names.insert(cap_addr, name);
 
         kernel_object
@@ -425,7 +423,7 @@ impl<'a> InitSystem<'a> {
                 cap_addr,
                 phys_addr,
             };
-            kernel_objects.push(kernel_object.clone());
+            kernel_objects.push(kernel_object);
             self.cap_address_names.insert(cap_addr, name);
 
             phys_addr += alloc_size;
@@ -1495,7 +1493,7 @@ fn build_system(
             "Page({} {}): MR={} @ {:x}",
             page_size_human, page_size_label, mr.name, phys_addr
         );
-        let page = init_system.allocate_fixed_object(phys_addr, obj_type, 1, name);
+        let page = init_system.allocate_fixed_object(phys_addr, obj_type, name);
         mr_pages.get_mut(mr).unwrap().push(page);
     }
 

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -27,7 +27,7 @@ pub struct BootInfo {
 /// The cap_address refers to a cap address that addresses this cap.
 /// The cap_address is is intended to be valid within the context of the
 /// initial task.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct Object {
     /// Type of kernel object
     pub object_type: ObjectType,
@@ -822,7 +822,7 @@ impl Invocation {
         cap_lookup: &HashMap<u64, String>,
     ) {
         let mut arg_strs = Vec::new();
-        let (service, service_str) = match self.args {
+        let (service, service_str): (u64, &str) = match self.args {
             InvocationArgs::UntypedRetype {
                 untyped,
                 object_type,
@@ -1052,7 +1052,7 @@ impl Invocation {
                 arg_strs.push(Invocation::fmt_field("extra_refills", extra_refills));
                 arg_strs.push(Invocation::fmt_field("badge", badge));
                 arg_strs.push(Invocation::fmt_field("flags", flags));
-                (sched_control, &"None".to_string())
+                (sched_control, "None")
             }
             InvocationArgs::ArmVcpuSetTcb { vcpu, tcb } => {
                 arg_strs.push(Invocation::fmt_field_cap("tcb", tcb, cap_lookup));


### PR DESCRIPTION
A byproduct of this part of the patch:

```diff
- (sched_control, &"None".to_string())
+ (sched_control, "None")
```

means that Rust toolchain versions lower than 1.79.0 can build the tool.