### PR TITLE
Disable 'KernelArmVtimerUpdateVOffset' by default

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -86,6 +86,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "ethernet": Path("example/tqma8xqp1gb/ethernet")
@@ -102,6 +103,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "hello": Path("example/zcu102/hello")
@@ -117,6 +119,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "hello": Path("example/maaxboard/hello")
@@ -132,6 +135,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "passive_server": Path("example/imx8mm_evk/passive_server")
@@ -147,6 +151,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "hello": Path("example/imx8mq_evk/hello")
@@ -162,6 +167,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "hello": Path("example/odroidc2/hello")
@@ -177,6 +183,7 @@ SUPPORTED_BOARDS = (
             "KernelIsMCS": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "timer": Path("example/odroidc4/timer")
@@ -195,6 +202,7 @@ SUPPORTED_BOARDS = (
             "KernelArmHypervisorSupport": True,
             "KernelArmExportPCNTUser": True,
             "KernelArmExportPTMRUser": True,
+            "KernelArmVtimerUpdateVOffset": False,
         },
         examples={
             "hello": Path("example/qemu_virt_aarch64/hello"),


### PR DESCRIPTION
This changes the behaviour of virtual machines to see the architectural timer change even when it is not running.

I do not understand why this option applies to all vCPUs in the kernel, instead of being behaviour that depends on the configuration of a particular vCPU.

I tried to learn more about this kernel configuration option in https://github.com/seL4/seL4/issues/1306 but no-one responded.