### PR TITLE
tool: make minimum Rust version 1.73.0

### DIFF
--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -8,7 +8,7 @@
 name = "microkit-tool"
 version = "1.4.0-dev"
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.73.0"
 
 [[bin]]
 name = "microkit"


### PR DESCRIPTION
The motivation is that 1.79.0 is still quite new so those who want to build all their tools from source with a pinned Rust version can build Microkit from source without upgrading.

Closes https://github.com/seL4/microkit/issues/198.