### PR TITLE
MaaXBoard loader address fix

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -113,7 +113,7 @@ SUPPORTED_BOARDS = (
         name="maaxboard",
         arch=KernelArch.AARCH64,
         gcc_cpu="cortex-a53",
-        loader_link_address=0x40480000,
+        loader_link_address=0x50000000,
         kernel_options={
             "KernelPlatform": "maaxboard",
             "KernelIsMCS": True,

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -744,7 +744,7 @@ The MaaXBoard is a low-cost ARM SBC based on the NXP i.MX8MQ system-on-chip.
 
 Microkit produces a raw binary file, so when using U-Boot you must execute the image using:
 
-    => go 0x40480000
+    => go 0x50000000
 
 ## Odroid-C2
 

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -270,7 +270,9 @@ impl<'a> Loader<'a> {
             }
         }
 
-        check_non_overlapping(&all_regions);
+        let mut all_regions_with_loader = all_regions.clone();
+        all_regions_with_loader.push((image_vaddr, &image));
+        check_non_overlapping(&all_regions_with_loader);
 
         let flags = match config.hypervisor {
             true => 1,


### PR DESCRIPTION
It was seen on larger Microkit systems that the loader data was
overlapping with the code for the loader itself when the loader
attempted to copy the data to the appropriate location before
jumping to seL4 and starting the system.

I believe the root cause of this problem is not gone and will involve
changing the tool to be smarter with how it allocates physical memory,
my current attempts to do so lead to other issues. I'll have to make a
follow up fix to prevent this from happening again, but for now this
will allow users of the MaaXBoard to run larger Microkit systems.

This PR also adds a patch to make sure that if overlapping does occur,
we find it at build time instead of having weird errors at runtime.