### PR TITLE
Add more error checking for memory mappings

### DIFF
--- a/tool/microkit/tests/sdf/sys_map_too_high.xml
+++ b/tool/microkit/tests/sdf/sys_map_too_high.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2021, Breakaway Consulting Pty. Ltd.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="foo" size="0x1_000" />
+    <protection_domain name="test1">
+        <program_image path="test" />
+        <!-- This number is 2^60. -->
+        <map mr="foo" vaddr="0x1000000000000000" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -22,15 +22,12 @@ const DEFAULT_KERNEL_CONFIG: sel4::Config = sel4::Config {
     riscv_pt_levels: None,
 };
 
-const DEFAULT_PLAT_DESC: sdf::PlatformDescription =
-    sdf::PlatformDescription::new(&DEFAULT_KERNEL_CONFIG);
-
 fn check_error(test_name: &str, expected_err: &str) {
     let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests/sdf/");
     path.push(test_name);
     let xml = std::fs::read_to_string(path).unwrap();
-    let parse_err = sdf::parse(test_name, &xml, &DEFAULT_PLAT_DESC).unwrap_err();
+    let parse_err = sdf::parse(test_name, &xml, &DEFAULT_KERNEL_CONFIG).unwrap_err();
 
     if !parse_err.starts_with(expected_err) {
         eprintln!(
@@ -405,6 +402,14 @@ mod system {
         check_error(
             "sys_map_not_aligned.xml",
             "Error: invalid vaddr alignment on 'map' @ ",
+        )
+    }
+
+    #[test]
+    fn test_map_too_high() {
+        check_error(
+            "sys_map_too_high.xml",
+            "Error: vaddr (0x1000000000000000) must be less than 0xfffffff000 on element 'map'",
         )
     }
 


### PR DESCRIPTION
This patch checks that a memory mapping is not at a virtual address that is greater than the maximum virtual address.