### PR TITLE
Allow mapping in virtual address of zero

### DIFF
--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -60,7 +60,6 @@ pub fn is_power_of_two(n: u64) -> bool {
 
 /// Mask out (set to zero) the lower bits from n
 pub fn mask_bits(n: u64, bits: u64) -> u64 {
-    assert!(n > 0);
     (n >> bits) << bits
 }
 


### PR DESCRIPTION
This usually does not make sense, e.g for normal native programs.

However, in the case of a virtual machine it does actually make sense since sometimes you are trying to emulate hardware where RAM (and hence guest RAM) may start at zero.

This assert was not necessary in the first place.