### PR TITLE
Add ability to specify version of SDK

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout Microkit repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
       - name: Checkout seL4 repository
         uses: actions/checkout@v4
         with:
@@ -47,18 +50,28 @@ jobs:
           wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf.tar.xz%3Frev%3D28d5199f6db34e5980aae1062e5a6703%26hash%3DF6F5604BC1A2BBAAEAC4F6E98D8DC35B
           tar xf aarch64-toolchain.tar.gz
           echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Set version
+        run: echo "SDK_VERSION=$(./ci/dev_version.sh)" >> $GITHUB_ENV
       - name: Build SDK
         run: |
           python3.9 -m venv pyenv
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4
+          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }}
+      - name: Upload SDK
+        uses: actions/upload-artifact@v4
+        with:
+          name: microkit-sdk-${{ env.SDK_VERSION }}-linux-x86-64
+          path: release/microkit-sdk-${{ env.SDK_VERSION }}.tar.gz
   build_macos_x64:
     name: Build SDK (macOS x86-64)
     runs-on: macos-14
     steps:
       - name: Checkout Microkit repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
       - name: Checkout seL4 repository
         uses: actions/checkout@v4
         with:
@@ -75,18 +88,28 @@ jobs:
           wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D09b11f159fc24fdda01e05bb32695dd5%26hash%3D6AAF4239F28AE17389AB3E611DFFE0A6
           tar xf aarch64-toolchain.tar.gz
           echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Set version
+        run: echo "SDK_VERSION=$(./ci/dev_version.sh)" >> $GITHUB_ENV
       - name: Build SDK
         run: |
           python3.9 -m venv pyenv
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4
+          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }}
+      - name: Upload SDK
+        uses: actions/upload-artifact@v4
+        with:
+          name: microkit-sdk-${{ env.SDK_VERSION }}-macos-x86-64
+          path: release/microkit-sdk-${{ env.SDK_VERSION }}.tar.gz
   build_macos_arm64:
     name: Build SDK (macOS ARM64)
     runs-on: macos-14
     steps:
       - name: Checkout Microkit repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
       - name: Checkout seL4 repository
         uses: actions/checkout@v4
         with:
@@ -104,9 +127,16 @@ jobs:
           wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D09b11f159fc24fdda01e05bb32695dd5%26hash%3D6AAF4239F28AE17389AB3E611DFFE0A6
           tar xf aarch64-toolchain.tar.gz
           echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Set version
+        run: echo "SDK_VERSION=$(./ci/dev_version.sh)" >> $GITHUB_ENV
       - name: Build SDK
         run: |
           python3.9 -m venv pyenv
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4 --tool-target-triple=aarch64-apple-darwin
+          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }}
+      - name: Upload SDK
+        uses: actions/upload-artifact@v4
+        with:
+          name: microkit-sdk-${{ env.SDK_VERSION }}-macos-aarch64
+          path: release/microkit-sdk-${{ env.SDK_VERSION }}.tar.gz

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -535,8 +535,11 @@ def main() -> None:
     parser.add_argument("--skip-sel4", action="store_true", help="seL4 will not be built")
     parser.add_argument("--skip-docs", action="store_true", help="Docs will not be built")
     parser.add_argument("--skip-tar", action="store_true", help="SDK and source tarballs will not be built")
+    parser.add_argument("--version", default=VERSION, help="SDK version")
 
     args = parser.parse_args()
+
+    version = args.version
 
     if args.boards is not None:
         supported_board_names = frozenset(board.name for board in SUPPORTED_BOARDS)
@@ -562,9 +565,9 @@ def main() -> None:
     if not sel4_dir.exists():
         raise Exception(f"sel4_dir: {sel4_dir} does not exist")
 
-    root_dir = Path("release") / f"{NAME}-sdk-{VERSION}"
-    tar_file = Path("release") / f"{NAME}-sdk-{VERSION}.tar.gz"
-    source_tar_file = Path("release") / f"{NAME}-source-{VERSION}.tar.gz"
+    root_dir = Path("release") / f"{NAME}-sdk-{version}"
+    tar_file = Path("release") / f"{NAME}-sdk-{version}.tar.gz"
+    source_tar_file = Path("release") / f"{NAME}-source-{version}.tar.gz"
     dir_structure = [
         root_dir / "bin",
         root_dir / "board",
@@ -656,7 +659,7 @@ def main() -> None:
         process = popen("git ls-files")
         filenames = [Path(fn.strip()) for fn in process.readlines()]
         process.close()
-        source_prefix = Path(f"{NAME}-source-{VERSION}")
+        source_prefix = Path(f"{NAME}-source-{version}")
         with tar_open(source_tar_file, "w:gz") as tar:
             for filename in filenames:
                 tar.add(filename, arcname=source_prefix / filename, filter=tar_filter)

--- a/ci/dev_version.sh
+++ b/ci/dev_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright 2024, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -e
+
+VERSION=`cat VERSION`
+LATEST_TAG=`git describe --tags --abbrev=0`
+NUM_COMMITS=`git rev-list --count $LATEST_TAG..HEAD`
+HEAD=`git rev-parse --short HEAD`
+
+echo "$VERSION.$NUM_COMMITS+$HEAD"


### PR DESCRIPTION
This will be used by CI for builds on each commit of Microkit, which will be useful for getting prebuillt SDKs between official releases.