### PR TITLE
Re-add warning for unused MRs

### DIFF
--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -1227,6 +1227,28 @@ pub fn parse(filename: &str, xml: &str, config: &Config) -> Result<SystemDescrip
         }
     }
 
+    // Check that all MRs are used
+    let mut all_maps = vec![];
+    for pd in &pds {
+        all_maps.extend(&pd.maps);
+        if let Some(vm) = &pd.virtual_machine {
+            all_maps.extend(&vm.maps);
+        }
+    }
+    for mr in &mrs {
+        let mut found = false;
+        for map in &all_maps {
+            if map.mr == mr.name {
+                found = true;
+                break;
+            }
+        }
+
+        if !found {
+            println!("WARNING: unused memory region '{}'", mr.name);
+        }
+    }
+
     Ok(SystemDescription {
         protection_domains: pds,
         memory_regions: mrs,


### PR DESCRIPTION
This was in the tool before it was rewritten to Rust, the omission of the warning was an oversight when I did the rewrite.