### PR TITLE
Allow specifying notify or ppcalls on a per-channel, not per-protection domain basis

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -638,7 +638,6 @@ The `protection_domain` element describes a protection domain.
 It supports the following attributes:
 
 * `name`: A unique name for the protection domain
-* `pp`: (optional) Indicates that the protection domain has a protected procedure; defaults to false.
 * `priority`: The priority of the protection domain (integer 0 to 254).
 * `budget`: (optional) The PD's budget in microseconds; defaults to 1,000.
 * `period`: (optional) The PD's period in microseconds; must not be smaller than the budget; defaults to the budget.
@@ -732,6 +731,9 @@ The `end` element has the following attributes:
 
 * `pd`: Name of the protection domain for this end.
 * `id`: Channel identifier in the context of the named protection domain. Must be at least 0 and less than 63.
+* `pp`: (optional) Indicates that the protection domain for this end can perform a protected procedure call to the other end; defaults to false.
+        Protected procedure calls can only be to PDs of strictly higher priority.
+* `notify`: (optional) Indicates that the protection domain for this end can send a notification to the other end; defaults to true.
 
 The `id` is passed to the PD in the `notified` and `protected` entry points.
 The `id` should be passed to the `microkit_notify` and `microkit_ppcall` functions.

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -3130,6 +3130,9 @@ impl<'a> Args<'a> {
         if config.is_none() {
             missing_args.push("--config");
         }
+        if system.is_none() {
+            missing_args.push("system");
+        }
 
         if !missing_args.is_empty() {
             print_usage(available_boards);

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -1201,6 +1201,22 @@ pub fn parse(filename: &str, xml: &str, config: &Config) -> Result<SystemDescrip
             ));
         }
 
+        let pd_a = &pds[ch.end_a.pd];
+        let pd_b = &pds[ch.end_b.pd];
+        if ch.end_a.pp && pd_a.priority >= pd_b.priority {
+            return Err(format!(
+                "Error: PPCs must be to protection domains of strictly higher priorities; \
+                        channel with PPC exists from pd {} (priority: {}) to pd {} (priority: {})",
+                pd_a.name, pd_a.priority, pd_b.name, pd_b.priority
+            ));
+        } else if ch.end_b.pp && pd_b.priority >= pd_a.priority {
+            return Err(format!(
+                "Error: PPCs must be to protection domains of strictly higher priorities; \
+                        channel with PPC exists from pd {} (priority: {}) to pd {} (priority: {})",
+                pd_b.name, pd_b.priority, pd_a.name, pd_a.priority
+            ));
+        }
+
         ch_ids[ch.end_a.pd].push(ch.end_a.id);
         ch_ids[ch.end_b.pd].push(ch.end_b.id);
     }

--- a/tool/microkit/tests/sdf/ch_bidirectional_ppc.xml
+++ b/tool/microkit/tests/sdf/ch_bidirectional_ppc.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2021, Breakaway Consulting Pty. Ltd.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+    <channel>
+        <end pd="test1" id="0" pp="true" />
+        <end pd="test2" id="0" pp="true" />
+    </channel>
+</system>

--- a/tool/microkit/tests/sdf/ch_end_invalid_notify.xml
+++ b/tool/microkit/tests/sdf/ch_end_invalid_notify.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+
+    <channel>
+        <end pd="test1" id="0" />
+        <end pd="test2" id="5" notify="no" />
+    </channel>
+</system>

--- a/tool/microkit/tests/sdf/ch_end_invalid_pp.xml
+++ b/tool/microkit/tests/sdf/ch_end_invalid_pp.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+
+    <channel>
+        <end pd="test1" id="0" pp="no" />
+        <end pd="test2" id="5"/>
+    </channel>
+</system>

--- a/tool/microkit/tests/sdf/ch_invalid_element.xml
+++ b/tool/microkit/tests/sdf/ch_invalid_element.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+
+    <channel>
+        <ending pd="test1" id="0" />
+        <end pd="test2" id="5" notify="true" />
+    </channel>
+</system>

--- a/tool/microkit/tests/sdf/ch_not_enough_ends.xml
+++ b/tool/microkit/tests/sdf/ch_not_enough_ends.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+
+    <channel>
+        <end pd="test1" id="5" notify="true" />
+    </channel>
+</system>

--- a/tool/microkit/tests/sdf/ch_ppcall_priority.xml
+++ b/tool/microkit/tests/sdf/ch_ppcall_priority.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1" priority="2">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2" priority="1">
+        <program_image path="test" />
+    </protection_domain>
+
+    <channel>
+        <end pd="test1" id="0" pp="true" />
+        <end pd="test2" id="0" />
+    </channel>
+</system>

--- a/tool/microkit/tests/sdf/ch_too_many_ends.xml
+++ b/tool/microkit/tests/sdf/ch_too_many_ends.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW.
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+
+    <channel>
+        <end pd="test1" id="5" notify="true" />
+        <end pd="test2" id="5" notify="true" />
+        <end pd="test2" id="5" notify="true" />
+    </channel>
+</system>

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -320,6 +320,54 @@ mod channel {
             "Error: invalid PD name 'invalidpd' on element 'end': ",
         )
     }
+
+    #[test]
+    fn test_invalid_element() {
+        check_error(
+            "ch_invalid_element.xml",
+            "Error: invalid XML element 'ending': ",
+        )
+    }
+
+    #[test]
+    fn test_not_enough_ends() {
+        check_error(
+            "ch_not_enough_ends.xml",
+            "Error: exactly two end elements must be specified on element 'channel': ",
+        )
+    }
+
+    #[test]
+    fn test_too_many_ends() {
+        check_error(
+            "ch_too_many_ends.xml",
+            "Error: exactly two end elements must be specified on element 'channel': ",
+        )
+    }
+
+    #[test]
+    fn test_end_invalid_pp() {
+        check_error(
+            "ch_end_invalid_pp.xml",
+            "Error: pp must be 'true' or 'false' on element 'end': ",
+        )
+    }
+
+    #[test]
+    fn test_end_invalid_notify() {
+        check_error(
+            "ch_end_invalid_notify.xml",
+            "Error: notify must be 'true' or 'false' on element 'end': ",
+        )
+    }
+
+    #[test]
+    fn test_bidirectional_ppc() {
+        check_error(
+            "ch_bidirectional_ppc.xml",
+            "Error: cannot ppc bidirectionally on element 'channel': ",
+        )
+    }
 }
 
 #[cfg(test)]

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -368,6 +368,14 @@ mod channel {
             "Error: cannot ppc bidirectionally on element 'channel': ",
         )
     }
+
+    #[test]
+    fn test_ppcall_priority() {
+        check_error(
+            "ch_ppcall_priority.xml",
+            "Error: PPCs must be to protection domains of strictly higher priorities; channel with PPC exists from pd test1 (priority: 2) to pd test2 (priority: 1)",
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Also fixes #168, as this allows us enough precision to check priorities.

Can specify `pp="true"` or `notify="false"` (or vice-versa, for the defaults):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<system>
    <protection_domain name="test1">
        <program_image path="test" />
    </protection_domain>
    <protection_domain name="test2">
        <program_image path="test" />
    </protection_domain>

    <channel>
        <end pd="test1" id="0" pp="true" notify="false" />
        <end pd="test2" id="5" />
    </channel>
</system>
```

ToDo:
- [x] Parsing tests
- [x] Behaviour tests (it works on at least one system, but...)
- [x] Probably documentation of changes (where?)
- [x] Enforcing ppcall priority invariant
- [x] Syntax bikeshedding

