### PR TITLE
ci: fix macOS x86-64 SDK artefact

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -80,6 +80,7 @@ jobs:
             path: seL4
       - name: Install SDK dependencies
         run: |
+          rustup target add x86_64-apple-darwin
           brew tap riscv-software-src/riscv
           brew install riscv-tools
           brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive qemu
@@ -95,7 +96,7 @@ jobs:
           python3.9 -m venv pyenv
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }}
+          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }} --tool-target-triple=x86_64-apple-darwin
       - name: Upload SDK
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Forgot to cross-compile the Microkit tool to x86-64.

This doesn't affect any of the released artefacts, just the per-commit ones.