### PR TITLE
Enable building SDK for Linux AArch64

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -16,8 +16,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build_linux_x64:
-    name: Build SDK (Linux x86-64)
+  build_linux:
+    name: Build SDK (Linux x86-64, ARM64)
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Microkit repository
@@ -34,6 +34,7 @@ jobs:
       - name: Install SDK dependencies
         run: |
           rustup target add x86_64-unknown-linux-musl
+          rustup target add aarch64-unknown-linux-musl
           sudo apt update
           sudo apt install software-properties-common
           sudo add-apt-repository ppa:deadsnakes/ppa
@@ -44,7 +45,10 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra \
             libxml2-utils \
             python3.9 python3-pip python3.9-venv \
-            qemu-system-arm qemu-system-misc \
+            qemu-system-arm qemu-system-misc
+          python3.9 -m venv pyenv
+          ./pyenv/bin/pip install --upgrade pip setuptools wheel
+          ./pyenv/bin/pip install -r requirements.txt
       - name: Install AArch64 GCC toolchain
         run: |
           wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf.tar.xz%3Frev%3D28d5199f6db34e5980aae1062e5a6703%26hash%3DF6F5604BC1A2BBAAEAC4F6E98D8DC35B
@@ -52,19 +56,22 @@ jobs:
           echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Set version
         run: echo "SDK_VERSION=$(./ci/dev_version.sh)" >> $GITHUB_ENV
-      - name: Build SDK
-        run: |
-          python3.9 -m venv pyenv
-          ./pyenv/bin/pip install --upgrade pip setuptools wheel
-          ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }}
-      - name: Upload SDK
+      - name: Build SDK (x86-64)
+        run: ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }} --tool-target-triple="x86_64-unknown-linux-musl"
+      - name: Upload SDK (x86-64)
         uses: actions/upload-artifact@v4
         with:
           name: microkit-sdk-${{ env.SDK_VERSION }}-linux-x86-64
           path: release/microkit-sdk-${{ env.SDK_VERSION }}.tar.gz
-  build_macos_x64:
-    name: Build SDK (macOS x86-64)
+      - name: Build SDK (ARM64)
+        run: ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }} --tool-target-triple="aarch64-unknown-linux-musl"
+      - name: Upload SDK (ARM64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: microkit-sdk-${{ env.SDK_VERSION }}-linux-aarch64
+          path: release/microkit-sdk-${{ env.SDK_VERSION }}.tar.gz
+  build_macos:
+    name: Build SDK (macOS x86-64, ARM64)
     runs-on: macos-14
     steps:
       - name: Checkout Microkit repository
@@ -81,9 +88,13 @@ jobs:
       - name: Install SDK dependencies
         run: |
           rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
           brew tap riscv-software-src/riscv
           brew install riscv-tools
           brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive qemu
+          python3.9 -m venv pyenv
+          ./pyenv/bin/pip install --upgrade pip setuptools wheel
+          ./pyenv/bin/pip install -r requirements.txt
       - name: Install AArch64 GCC toolchain
         run: |
           wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D09b11f159fc24fdda01e05bb32695dd5%26hash%3D6AAF4239F28AE17389AB3E611DFFE0A6
@@ -91,52 +102,16 @@ jobs:
           echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Set version
         run: echo "SDK_VERSION=$(./ci/dev_version.sh)" >> $GITHUB_ENV
-      - name: Build SDK
-        run: |
-          python3.9 -m venv pyenv
-          ./pyenv/bin/pip install --upgrade pip setuptools wheel
-          ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }} --tool-target-triple=x86_64-apple-darwin
-      - name: Upload SDK
+      - name: Build SDK (x86-64)
+        run: ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }} --tool-target-triple=x86_64-apple-darwin
+      - name: Upload SDK (x86-64)
         uses: actions/upload-artifact@v4
         with:
           name: microkit-sdk-${{ env.SDK_VERSION }}-macos-x86-64
           path: release/microkit-sdk-${{ env.SDK_VERSION }}.tar.gz
-  build_macos_arm64:
-    name: Build SDK (macOS ARM64)
-    runs-on: macos-14
-    steps:
-      - name: Checkout Microkit repository
-        uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-          fetch-depth: 0
-      - name: Checkout seL4 repository
-        uses: actions/checkout@v4
-        with:
-            repository: seL4/seL4
-            ref: microkit
-            path: seL4
-      - name: Install SDK dependencies
-        run: |
-          rustup target add aarch64-apple-darwin
-          brew tap riscv-software-src/riscv
-          brew install riscv-tools
-          brew install pandoc cmake dtc ninja qemu libxml2 python@3.9 coreutils texlive
-      - name: Install AArch64 GCC toolchain
-        run: |
-          wget -O aarch64-toolchain.tar.gz https://sel4-toolchains.s3.us-east-2.amazonaws.com/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D09b11f159fc24fdda01e05bb32695dd5%26hash%3D6AAF4239F28AE17389AB3E611DFFE0A6
-          tar xf aarch64-toolchain.tar.gz
-          echo "$(pwd)/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
-      - name: Set version
-        run: echo "SDK_VERSION=$(./ci/dev_version.sh)" >> $GITHUB_ENV
-      - name: Build SDK
-        run: |
-          python3.9 -m venv pyenv
-          ./pyenv/bin/pip install --upgrade pip setuptools wheel
-          ./pyenv/bin/pip install -r requirements.txt
-          ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }}
-      - name: Upload SDK
+      - name: Build SDK (ARM64)
+        run: ./pyenv/bin/python build_sdk.py --sel4=seL4 --version ${{ env.SDK_VERSION }} --tool-target-triple=aarch64-apple-darwin
+      - name: Upload SDK (ARM64)
         uses: actions/upload-artifact@v4
         with:
           name: microkit-sdk-${{ env.SDK_VERSION }}-macos-aarch64

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -350,9 +350,6 @@ def build_tool(tool_target: Path, target_triple: str) -> None:
 
     tool_output = f"./tool/microkit/target/{target_triple}/release/microkit"
 
-    r = system(f"strip {tool_output}")
-    assert r == 0
-
     copy(tool_output, tool_target)
 
     tool_target.chmod(0o755)

--- a/tool/microkit/.cargo/config.toml
+++ b/tool/microkit/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Copyright 2024, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-none-elf-ld"

--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -18,3 +18,6 @@ path = "src/main.rs"
 roxmltree = "0.19.0"
 serde = "1.0.203"
 serde_json = "1.0.117"
+
+[profile.release]
+strip = true


### PR DESCRIPTION
Rust's cross-compiling is limited so this only works from a Linux host, if you're on macOS it won't work.