### PR TITLE
Fix linking of tool on Linux AArch64

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -45,7 +45,8 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra \
             libxml2-utils \
             python3.9 python3-pip python3.9-venv \
-            qemu-system-arm qemu-system-misc
+            qemu-system-arm qemu-system-misc \
+            gcc-aarch64-linux-gnu
           python3.9 -m venv pyenv
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt

--- a/tool/microkit/.cargo/config.toml
+++ b/tool/microkit/.cargo/config.toml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 [target.aarch64-unknown-linux-musl]
-linker = "aarch64-none-elf-ld"
+linker = "aarch64-linux-gnu-ld"


### PR DESCRIPTION
I specified the linker to `aarch64-none-elf-ld` because I would've thought that even though we are targeting Linux, the linker shouldn't matter but on Linux AArch64 we get a segfault when running the Microkit tool.

Changing the linker to `aarch64-linux-gnu-ld` fixes that.

I'm not really happy with this solution as we now have to install a new C toolchain just to compile a Rust program, from searching on the internet the solution seems to be to use the cross-rs package, which just uses Docker containers so isn't actually cross compiling anything.

If anyone has any better ideas please let me know.