### PR TITLE
Use rust-lld for linking tool on Linux AArch64

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -45,8 +45,7 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra \
             libxml2-utils \
             python3.9 python3-pip python3.9-venv \
-            qemu-system-arm qemu-system-misc \
-            gcc-aarch64-linux-gnu
+            qemu-system-arm qemu-system-misc
           python3.9 -m venv pyenv
           ./pyenv/bin/pip install --upgrade pip setuptools wheel
           ./pyenv/bin/pip install -r requirements.txt

--- a/tool/microkit/.cargo/config.toml
+++ b/tool/microkit/.cargo/config.toml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 [target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-gnu-ld"
+rustflags = ["-Clinker=rust-lld"]


### PR DESCRIPTION
Doesn't require a new dependency and still seems to work.

Thanks @midnightveil who told me about it.