### PR TITLE
Increase max PD name length to 64

### DIFF
--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -28,6 +28,7 @@ typedef seL4_MessageInfo_t microkit_msginfo;
 #define BASE_VCPU_CAP 330
 
 #define MICROKIT_MAX_CHANNELS 62
+#define MICROKIT_PD_NAME_LENGTH 64
 
 /* User provided functions */
 void init(void);
@@ -35,7 +36,7 @@ void notified(microkit_channel ch);
 microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo);
 seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo);
 
-extern char microkit_name[16];
+extern char microkit_name[MICROKIT_PD_NAME_LENGTH];
 /* These next three variables are so our PDs can combine a signal with the next Recv syscall */
 extern seL4_Bool microkit_have_signal;
 extern seL4_CPtr microkit_signal_cap;

--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -21,7 +21,7 @@
 /* All globals are prefixed with microkit_* to avoid clashes with user defined globals. */
 
 bool microkit_passive;
-char microkit_name[16];
+char microkit_name[MICROKIT_PD_NAME_LENGTH];
 /* We use seL4 typedefs as this variable is exposed to the libmicrokit header
  * and we do not want to rely on compiler built-in defines. */
 seL4_Bool microkit_have_signal = seL4_False;

--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -66,7 +66,7 @@
 #include "debug.h"
 
 #define MAX_PDS 64
-#define MAX_NAME_LEN 16
+#define MAX_NAME_LEN 64
 #define MAX_TCBS 64
 
 #define MAX_UNTYPED_REGIONS 256

--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -20,7 +20,7 @@ pub const MAX_PDS: usize = 63;
 // It should be noted that if you were to change the value of
 // the maximum PD name length, you would also have to change
 // the monitor and libmicrokit.
-pub const PD_MAX_NAME_LENGTH: usize = 16;
+pub const PD_MAX_NAME_LENGTH: usize = 64;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UntypedObject {

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -3580,6 +3580,9 @@ fn main() -> Result<(), String> {
         let name_length = min(name.len(), PD_MAX_NAME_LENGTH);
         let end = start + name_length;
         pd_names_bytes[start..end].copy_from_slice(&name[..name_length]);
+        // These bytes will be interpreted as a C string, so we must include
+        // a null-terminator.
+        pd_names_bytes[start + PD_MAX_NAME_LENGTH - 1] = 0;
     }
     monitor_elf.write_symbol("pd_names", &pd_names_bytes)?;
 


### PR DESCRIPTION
Also adds a null terminating at the end of the string when patching the monitor's PD name array. This fixes the monitor output when there exists a PD that has a name that exceeds the max name length.