### PR TITLE
Load invocation numbers from JSON file

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -431,6 +431,12 @@ def build_sel4(
     # Make output read-only
     dest.chmod(0o744)
 
+    invocations_all = sel4_build_dir / "generated" / "invocations_all.json"
+    dest = (root_dir / "board" / board.name / config.name / "invocations_all.json")
+    dest.unlink(missing_ok=True)
+    copy(invocations_all, dest)
+    dest.chmod(0o744)
+
     include_dir = root_dir / "board" / board.name / config.name / "include"
     for source in ("kernel_Config", "libsel4", "libsel4/sel4_Config", "libsel4/autoconf"):
         source_dir = sel4_install_dir / source / "include"

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -3214,6 +3214,12 @@ fn main() -> Result<(), String> {
         .join(args.config)
         .join("include/kernel/gen_config.json");
 
+    let invocations_all_path = sdk_dir
+        .join("board")
+        .join(args.board)
+        .join(args.config)
+        .join("invocations_all.json");
+
     if !elf_path.exists() {
         eprintln!(
             "Error: board ELF directory '{}' does not exist",
@@ -3249,6 +3255,13 @@ fn main() -> Result<(), String> {
         );
         std::process::exit(1);
     }
+    if !invocations_all_path.exists() {
+        eprintln!(
+            "Error: invocations JSON file '{}' does not exist",
+            invocations_all_path.display()
+        );
+        std::process::exit(1);
+    }
 
     let system_path = Path::new(args.system);
     if !system_path.exists() {
@@ -3263,6 +3276,9 @@ fn main() -> Result<(), String> {
 
     let kernel_config_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(kernel_config_path).unwrap()).unwrap();
+
+    let invocations_labels: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(invocations_all_path).unwrap()).unwrap();
 
     let arch = match json_str(&kernel_config_json, "SEL4_ARCH")? {
         "aarch64" => Arch::Aarch64,
@@ -3314,6 +3330,7 @@ fn main() -> Result<(), String> {
         arm_pa_size_bits,
         arm_smc,
         riscv_pt_levels: Some(RiscvVirtualMemory::Sv39),
+        invocations_labels,
     };
 
     if let Arch::Aarch64 = kernel_config.arch {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -56,6 +56,7 @@ pub struct Config {
     pub arm_smc: Option<bool>,
     /// RISC-V specific, what kind of virtual memory system (e.g Sv39)
     pub riscv_pt_levels: Option<RiscvVirtualMemory>,
+    pub invocations_labels: serde_json::Value,
 }
 
 impl Config {
@@ -341,35 +342,35 @@ enum InvocationLabel {
     // Untyped
     UntypedRetype,
     // TCB
-    TcbReadRegisters,
-    TcbWriteRegisters,
-    TcbCopyRegisters,
-    TcbConfigure,
-    TcbSetPriority,
-    TcbSetMCPriority,
-    TcbSetSchedParams,
-    TcbSetTimeoutEndpoint,
-    TcbSetIpcBuffer,
-    TcbSetSpace,
-    TcbSuspend,
-    TcbResume,
-    TcbBindNotification,
-    TcbUnbindNotification,
-    TcbSetTLSBase,
+    TCBReadRegisters,
+    TCBWriteRegisters,
+    TCBCopyRegisters,
+    TCBConfigure,
+    TCBSetPriority,
+    TCBSetMCPriority,
+    TCBSetSchedParams,
+    TCBSetTimeoutEndpoint,
+    TCBSetIPCBuffer,
+    TCBSetSpace,
+    TCBSuspend,
+    TCBResume,
+    TCBBindNotification,
+    TCBUnbindNotification,
+    TCBSetTLSBase,
     // CNode
-    CnodeRevoke,
-    CnodeDelete,
-    CnodeCancelBadgedSends,
-    CnodeCopy,
-    CnodeMint,
-    CnodeMove,
-    CnodeMutate,
-    CnodeRotate,
+    CNodeRevoke,
+    CNodeDelete,
+    CNodeCancelBadgedSends,
+    CNodeCopy,
+    CNodeMint,
+    CNodeMove,
+    CNodeMutate,
+    CNodeRotate,
     // IRQ
-    IrqIssueIrqHandler,
-    IrqAckIrq,
-    IrqSetIrqHandler,
-    IrqClearIrqHandler,
+    IRQIssueIRQHandler,
+    IRQAckIRQ,
+    IRQSetIRQHandler,
+    IRQClearIRQHandler,
     // Domain
     DomainSetSet,
     // Scheduling
@@ -380,133 +381,51 @@ enum InvocationLabel {
     SchedContextConsume,
     SchedContextYieldTo,
     // ARM VSpace
-    ArmVspaceCleanData,
-    ArmVspaceInvalidateData,
-    ArmVspaceCleanInvalidateData,
-    ArmVspaceUnifyInstruction,
+    ARMVSpaceCleanData,
+    ARMVSpaceInvalidateData,
+    ARMVSpaceCleanInvalidateData,
+    ARMVSpaceUnifyInstruction,
     // ARM SMC
-    ArmSmcCall,
+    ARMSMCCall,
     // ARM Page table
-    ArmPageTableMap,
-    ArmPageTableUnmap,
+    ARMPageTableMap,
+    ARMPageTableUnmap,
     // ARM Page
-    ArmPageMap,
-    ArmPageUnmap,
-    ArmPageCleanData,
-    ArmPageInvalidateData,
-    ArmPageCleanInvalidateData,
-    ArmPageUnifyInstruction,
-    ArmPageGetAddress,
+    ARMPageMap,
+    ARMPageUnmap,
+    ARMPageCleanData,
+    ARMPageInvalidateData,
+    ARMPageCleanInvalidateData,
+    ARMPageUnifyInstruction,
+    ARMPageGetAddress,
     // ARM Asid
-    ArmAsidControlMakePool,
-    ArmAsidPoolAssign,
+    ARMASIDControlMakePool,
+    ARMASIDPoolAssign,
     // ARM vCPU
-    ArmVcpuSetTcb,
-    ArmVcpuInjectIrq,
-    ArmVcpuReadReg,
-    ArmVcpuWriteReg,
-    ArmVcpuAckVppi,
+    ARMVCPUSetTCB,
+    ARMVCPUInjectIRQ,
+    ARMVCPUReadReg,
+    ARMVCPUWriteReg,
+    ARMVCPUAckVppi,
     // ARM IRQ
-    ArmIrqIssueIrqHandlerTrigger,
+    ARMIRQIssueIRQHandlerTrigger,
     // RISC-V Page Table
-    RiscvPageTableMap,
-    RiscvPageTableUnmap,
+    RISCVPageTableMap,
+    RISCVPageTableUnmap,
     // RISC-V Page
-    RiscvPageMap,
-    RiscvPageUnmap,
-    RiscvPageGetAddress,
+    RISCVPageMap,
+    RISCVPageUnmap,
+    RISCVPageGetAddress,
     // RISC-V ASID
-    RiscvAsidControlMakePool,
-    RiscvAsidPoolAssign,
+    RISCVASIDControlMakePool,
+    RISCVASIDPoolAssign,
     // RISC-V IRQ
-    RiscvIrqIssueIrqHandlerTrigger,
+    RISCVIRQIssueIRQHandlerTrigger,
 }
 
-impl InvocationLabel {
-    /// Convert an invocation's named label to the value seL4 expects when
-    /// you make the invocation.
-    pub fn to_value(self) -> u32 {
-        match self {
-            InvocationLabel::UntypedRetype => 1,
-            InvocationLabel::TcbReadRegisters => 2,
-            InvocationLabel::TcbWriteRegisters => 3,
-            InvocationLabel::TcbCopyRegisters => 4,
-            InvocationLabel::TcbConfigure => 5,
-            InvocationLabel::TcbSetPriority => 6,
-            InvocationLabel::TcbSetMCPriority => 7,
-            InvocationLabel::TcbSetSchedParams => 8,
-            InvocationLabel::TcbSetTimeoutEndpoint => 9,
-            InvocationLabel::TcbSetIpcBuffer => 10,
-            InvocationLabel::TcbSetSpace => 11,
-            InvocationLabel::TcbSuspend => 12,
-            InvocationLabel::TcbResume => 13,
-            InvocationLabel::TcbBindNotification => 14,
-            InvocationLabel::TcbUnbindNotification => 15,
-            InvocationLabel::TcbSetTLSBase => 16,
-            // CNode
-            InvocationLabel::CnodeRevoke => 17,
-            InvocationLabel::CnodeDelete => 18,
-            InvocationLabel::CnodeCancelBadgedSends => 19,
-            InvocationLabel::CnodeCopy => 20,
-            InvocationLabel::CnodeMint => 21,
-            InvocationLabel::CnodeMove => 22,
-            InvocationLabel::CnodeMutate => 23,
-            InvocationLabel::CnodeRotate => 24,
-            // IRQ
-            InvocationLabel::IrqIssueIrqHandler => 25,
-            InvocationLabel::IrqAckIrq => 26,
-            InvocationLabel::IrqSetIrqHandler => 27,
-            InvocationLabel::IrqClearIrqHandler => 28,
-            // Domain
-            InvocationLabel::DomainSetSet => 29,
-            // Scheduling
-            InvocationLabel::SchedControlConfigureFlags => 30,
-            InvocationLabel::SchedContextBind => 31,
-            InvocationLabel::SchedContextUnbind => 32,
-            InvocationLabel::SchedContextUnbindObject => 33,
-            InvocationLabel::SchedContextConsume => 34,
-            InvocationLabel::SchedContextYieldTo => 35,
-            // ARM VSpace
-            InvocationLabel::ArmVspaceCleanData => 36,
-            InvocationLabel::ArmVspaceInvalidateData => 37,
-            InvocationLabel::ArmVspaceCleanInvalidateData => 38,
-            InvocationLabel::ArmVspaceUnifyInstruction => 39,
-            // ARM SMC
-            InvocationLabel::ArmSmcCall => 40,
-            // ARM Page table
-            InvocationLabel::ArmPageTableMap => 41,
-            InvocationLabel::ArmPageTableUnmap => 42,
-            // ARM Page
-            InvocationLabel::ArmPageMap => 43,
-            InvocationLabel::ArmPageUnmap => 44,
-            InvocationLabel::ArmPageCleanData => 45,
-            InvocationLabel::ArmPageInvalidateData => 46,
-            InvocationLabel::ArmPageCleanInvalidateData => 47,
-            InvocationLabel::ArmPageUnifyInstruction => 48,
-            InvocationLabel::ArmPageGetAddress => 49,
-            // ARM ASID
-            InvocationLabel::ArmAsidControlMakePool => 50,
-            InvocationLabel::ArmAsidPoolAssign => 51,
-            // ARM vCPU
-            InvocationLabel::ArmVcpuSetTcb => 52,
-            InvocationLabel::ArmVcpuInjectIrq => 53,
-            InvocationLabel::ArmVcpuReadReg => 54,
-            InvocationLabel::ArmVcpuWriteReg => 55,
-            InvocationLabel::ArmVcpuAckVppi => 56,
-            // ARM IRQ
-            InvocationLabel::ArmIrqIssueIrqHandlerTrigger => 57,
-            // RISC-V Page
-            InvocationLabel::RiscvPageTableMap => 36,
-            InvocationLabel::RiscvPageTableUnmap => 37,
-            InvocationLabel::RiscvPageMap => 38,
-            InvocationLabel::RiscvPageUnmap => 39,
-            InvocationLabel::RiscvPageGetAddress => 40,
-            // RISC-V ASID
-            InvocationLabel::RiscvAsidControlMakePool => 41,
-            InvocationLabel::RiscvAsidPoolAssign => 42,
-            // RISC-V IRQ
-            InvocationLabel::RiscvIrqIssueIrqHandlerTrigger => 43,
-        }
+impl std::fmt::Display for InvocationLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -743,7 +662,13 @@ impl Invocation {
         let label = args.to_label(config);
         Invocation {
             label,
-            label_raw: label.to_value(),
+            label_raw: config.invocations_labels[label.to_string()]
+                .as_number()
+                .expect("Invocation is not a number")
+                .as_u64()
+                .expect("Invocation is not u64")
+                .try_into()
+                .expect("Invocation is not u32"),
             args,
             repeat: None,
         }
@@ -1112,23 +1037,23 @@ impl Invocation {
     fn object_type(&self) -> &'static str {
         match self.label {
             InvocationLabel::UntypedRetype => "Untyped",
-            InvocationLabel::TcbSetSchedParams
-            | InvocationLabel::TcbSetSpace
-            | InvocationLabel::TcbSetIpcBuffer
-            | InvocationLabel::TcbResume
-            | InvocationLabel::TcbWriteRegisters
-            | InvocationLabel::TcbBindNotification => "TCB",
-            InvocationLabel::ArmAsidPoolAssign | InvocationLabel::RiscvAsidPoolAssign => {
+            InvocationLabel::TCBSetSchedParams
+            | InvocationLabel::TCBSetSpace
+            | InvocationLabel::TCBSetIPCBuffer
+            | InvocationLabel::TCBResume
+            | InvocationLabel::TCBWriteRegisters
+            | InvocationLabel::TCBBindNotification => "TCB",
+            InvocationLabel::ARMASIDPoolAssign | InvocationLabel::RISCVASIDPoolAssign => {
                 "ASID Pool"
             }
-            InvocationLabel::ArmIrqIssueIrqHandlerTrigger
-            | InvocationLabel::RiscvIrqIssueIrqHandlerTrigger => "IRQ Control",
-            InvocationLabel::IrqSetIrqHandler => "IRQ Handler",
-            InvocationLabel::ArmPageTableMap | InvocationLabel::RiscvPageTableMap => "Page Table",
-            InvocationLabel::ArmPageMap | InvocationLabel::RiscvPageMap => "Page",
-            InvocationLabel::CnodeCopy | InvocationLabel::CnodeMint => "CNode",
+            InvocationLabel::ARMIRQIssueIRQHandlerTrigger
+            | InvocationLabel::RISCVIRQIssueIRQHandlerTrigger => "IRQ Control",
+            InvocationLabel::IRQSetIRQHandler => "IRQ Handler",
+            InvocationLabel::ARMPageTableMap | InvocationLabel::RISCVPageTableMap => "Page Table",
+            InvocationLabel::ARMPageMap | InvocationLabel::RISCVPageMap => "Page",
+            InvocationLabel::CNodeCopy | InvocationLabel::CNodeMint => "CNode",
             InvocationLabel::SchedControlConfigureFlags => "SchedControl",
-            InvocationLabel::ArmVcpuSetTcb => "VCPU",
+            InvocationLabel::ARMVCPUSetTCB => "VCPU",
             _ => panic!(
                 "Internal error: unexpected label when getting object type '{:?}'",
                 self.label
@@ -1139,24 +1064,24 @@ impl Invocation {
     fn method_name(&self) -> &'static str {
         match self.label {
             InvocationLabel::UntypedRetype => "Retype",
-            InvocationLabel::TcbSetSchedParams => "SetSchedParams",
-            InvocationLabel::TcbSetSpace => "SetSpace",
-            InvocationLabel::TcbSetIpcBuffer => "SetIPCBuffer",
-            InvocationLabel::TcbResume => "Resume",
-            InvocationLabel::TcbWriteRegisters => "WriteRegisters",
-            InvocationLabel::TcbBindNotification => "BindNotification",
-            InvocationLabel::ArmAsidPoolAssign | InvocationLabel::RiscvAsidPoolAssign => "Assign",
-            InvocationLabel::ArmIrqIssueIrqHandlerTrigger
-            | InvocationLabel::RiscvIrqIssueIrqHandlerTrigger => "Get",
-            InvocationLabel::IrqSetIrqHandler => "SetNotification",
-            InvocationLabel::ArmPageTableMap
-            | InvocationLabel::ArmPageMap
-            | InvocationLabel::RiscvPageTableMap
-            | InvocationLabel::RiscvPageMap => "Map",
-            InvocationLabel::CnodeCopy => "Copy",
-            InvocationLabel::CnodeMint => "Mint",
+            InvocationLabel::TCBSetSchedParams => "SetSchedParams",
+            InvocationLabel::TCBSetSpace => "SetSpace",
+            InvocationLabel::TCBSetIPCBuffer => "SetIPCBuffer",
+            InvocationLabel::TCBResume => "Resume",
+            InvocationLabel::TCBWriteRegisters => "WriteRegisters",
+            InvocationLabel::TCBBindNotification => "BindNotification",
+            InvocationLabel::ARMASIDPoolAssign | InvocationLabel::RISCVASIDPoolAssign => "Assign",
+            InvocationLabel::ARMIRQIssueIRQHandlerTrigger
+            | InvocationLabel::RISCVIRQIssueIRQHandlerTrigger => "Get",
+            InvocationLabel::IRQSetIRQHandler => "SetNotification",
+            InvocationLabel::ARMPageTableMap
+            | InvocationLabel::ARMPageMap
+            | InvocationLabel::RISCVPageTableMap
+            | InvocationLabel::RISCVPageMap => "Map",
+            InvocationLabel::CNodeCopy => "Copy",
+            InvocationLabel::CNodeMint => "Mint",
             InvocationLabel::SchedControlConfigureFlags => "ConfigureFlags",
-            InvocationLabel::ArmVcpuSetTcb => "VCPUSetTcb",
+            InvocationLabel::ARMVCPUSetTCB => "VCPUSetTcb",
             _ => panic!(
                 "Internal error: unexpected label when getting method name '{:?}'",
                 self.label
@@ -1169,35 +1094,35 @@ impl InvocationArgs {
     fn to_label(&self, config: &Config) -> InvocationLabel {
         match self {
             InvocationArgs::UntypedRetype { .. } => InvocationLabel::UntypedRetype,
-            InvocationArgs::TcbSetSchedParams { .. } => InvocationLabel::TcbSetSchedParams,
-            InvocationArgs::TcbSetSpace { .. } => InvocationLabel::TcbSetSpace,
-            InvocationArgs::TcbSetIpcBuffer { .. } => InvocationLabel::TcbSetIpcBuffer,
-            InvocationArgs::TcbResume { .. } => InvocationLabel::TcbResume,
-            InvocationArgs::TcbWriteRegisters { .. } => InvocationLabel::TcbWriteRegisters,
-            InvocationArgs::TcbBindNotification { .. } => InvocationLabel::TcbBindNotification,
+            InvocationArgs::TcbSetSchedParams { .. } => InvocationLabel::TCBSetSchedParams,
+            InvocationArgs::TcbSetSpace { .. } => InvocationLabel::TCBSetSpace,
+            InvocationArgs::TcbSetIpcBuffer { .. } => InvocationLabel::TCBSetIPCBuffer,
+            InvocationArgs::TcbResume { .. } => InvocationLabel::TCBResume,
+            InvocationArgs::TcbWriteRegisters { .. } => InvocationLabel::TCBWriteRegisters,
+            InvocationArgs::TcbBindNotification { .. } => InvocationLabel::TCBBindNotification,
             InvocationArgs::AsidPoolAssign { .. } => match config.arch {
-                Arch::Aarch64 => InvocationLabel::ArmAsidPoolAssign,
-                Arch::Riscv64 => InvocationLabel::RiscvAsidPoolAssign,
+                Arch::Aarch64 => InvocationLabel::ARMASIDPoolAssign,
+                Arch::Riscv64 => InvocationLabel::RISCVASIDPoolAssign,
             },
             InvocationArgs::IrqControlGetTrigger { .. } => match config.arch {
-                Arch::Aarch64 => InvocationLabel::ArmIrqIssueIrqHandlerTrigger,
-                Arch::Riscv64 => InvocationLabel::RiscvIrqIssueIrqHandlerTrigger,
+                Arch::Aarch64 => InvocationLabel::ARMIRQIssueIRQHandlerTrigger,
+                Arch::Riscv64 => InvocationLabel::RISCVIRQIssueIRQHandlerTrigger,
             },
-            InvocationArgs::IrqHandlerSetNotification { .. } => InvocationLabel::IrqSetIrqHandler,
+            InvocationArgs::IrqHandlerSetNotification { .. } => InvocationLabel::IRQSetIRQHandler,
             InvocationArgs::PageTableMap { .. } => match config.arch {
-                Arch::Aarch64 => InvocationLabel::ArmPageTableMap,
-                Arch::Riscv64 => InvocationLabel::RiscvPageTableMap,
+                Arch::Aarch64 => InvocationLabel::ARMPageTableMap,
+                Arch::Riscv64 => InvocationLabel::RISCVPageTableMap,
             },
             InvocationArgs::PageMap { .. } => match config.arch {
-                Arch::Aarch64 => InvocationLabel::ArmPageMap,
-                Arch::Riscv64 => InvocationLabel::RiscvPageMap,
+                Arch::Aarch64 => InvocationLabel::ARMPageMap,
+                Arch::Riscv64 => InvocationLabel::RISCVPageMap,
             },
-            InvocationArgs::CnodeCopy { .. } => InvocationLabel::CnodeCopy,
-            InvocationArgs::CnodeMint { .. } => InvocationLabel::CnodeMint,
+            InvocationArgs::CnodeCopy { .. } => InvocationLabel::CNodeCopy,
+            InvocationArgs::CnodeMint { .. } => InvocationLabel::CNodeMint,
             InvocationArgs::SchedControlConfigureFlags { .. } => {
                 InvocationLabel::SchedControlConfigureFlags
             }
-            InvocationArgs::ArmVcpuSetTcb { .. } => InvocationLabel::ArmVcpuSetTcb,
+            InvocationArgs::ArmVcpuSetTcb { .. } => InvocationLabel::ARMVCPUSetTCB,
         }
     }
 

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -5,6 +5,7 @@
 //
 
 use microkit_tool::{sdf, sel4};
+use serde_json::json;
 
 const DEFAULT_KERNEL_CONFIG: sel4::Config = sel4::Config {
     arch: sel4::Arch::Aarch64,
@@ -21,6 +22,8 @@ const DEFAULT_KERNEL_CONFIG: sel4::Config = sel4::Config {
     arm_pa_size_bits: Some(40),
     arm_smc: None,
     riscv_pt_levels: None,
+    // Not necessary for SDF parsing
+    invocations_labels: json!(null),
 };
 
 fn check_error(test_name: &str, expected_err: &str) {


### PR DESCRIPTION
Instead of hard-coding invocation numbers, we now
get them from a file generated by the seL4 kernel
build.

Depends on: [bd1c39240944207ef71237f98663acb06cc971f6](https://github.com/seL4/seL4/commit/bd1c39240944207ef71237f98663acb06cc971f6)