### PR TITLE
libmicrokit: add error message for entry points not provided

### DIFF
--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -37,11 +37,17 @@ extern const void (*const __init_array_end [])(void);
 
 __attribute__((weak)) microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
 {
+    microkit_dbg_puts(microkit_name);
+    microkit_dbg_puts(" is missing the 'protected' entry point\n");
+    microkit_internal_crash(0);
     return seL4_MessageInfo_new(0, 0, 0, 0);
 }
 
 __attribute__((weak)) seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo)
 {
+    microkit_dbg_puts(microkit_name);
+    microkit_dbg_puts(" is missing the 'fault' entry point\n");
+    microkit_internal_crash(0);
     return seL4_False;
 }
 


### PR DESCRIPTION
In order to have libmicrokit compiling with PDs that do not provide the 'protected' or 'fault' entry points, we have empty implementations of them.

This has an unfortunate consequence that if a programmer forgets to provide implementations of these entry points, things will silently fail.