### PR TITLE
Allow building the SDK with a custom toolchain prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Testing has been performed using commit `4cae30a6ef166a378d4d23697b00106ce7e4e76
 
     $ ./pyenv/bin/python build_sdk.py --sel4=<path to sel4>
 
+The SDK will be in `release/`.
+
+See the help menu of `build_sdk.py` for configuring how the SDK is built:
+
+    $ ./pyenv/bin/python build_sdk.py --help
+
 ## Using the SDK
 
 After building the SDK you probably want to build a system!


### PR DESCRIPTION
Allow building the SDK with a custom toolchain prefix

We will always have an official, 'supported' C toolchain but it has
become apparent that:
1. GCC toolchain triples are a complete, inconsistent mess.
2. People may have vendored toolchains that they must use when compiling
   from source.

Therefore, we introduce arguments to the build_sdk.py script that allows
overriding the default prefixes.

Closes https://github.com/seL4/microkit/issues/201.