### PR TITLE
Fix bintools in Nix flake for macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
           nativeBuildInputs = with pkgs; [
             pkgsCross.aarch64-embedded.stdenv.cc.bintools
             pkgsCross.aarch64-embedded.stdenv.cc.cc
-            pkgsCross.riscv64-embedded.stdenv.cc.bintools
+            pkgsCross.riscv64-embedded.stdenv.cc.bintools.bintools
             pkgsCross.riscv64-embedded.stdenv.cc.cc
             gnumake
             dtc


### PR DESCRIPTION
We want the unwrapped bintools so we don't have weird extra arguments such as '-liconv'. iconv doesn't exist on macOS by default I believe so we were encountering 'library not found' errors even though the Nix flake on Linux was working fine.