### PR TITLE
Add VERSION file to SDK layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ The SDK top-level directory is `microkit-sdk-$VERSION`.
 The directory layout underneath the top-level directory is:
 
 ```
+VERSION
+LICENSE.md
+LICENSES/$licence.txt
 doc/
 doc/microkit_user_manual.pdf
 bin/

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -631,6 +631,9 @@ def main() -> None:
     for dr in dir_structure:
         dr.mkdir(exist_ok=True, parents=True)
 
+    with open(root_dir / "VERSION", "w+") as f:
+        f.write(version + "\n")
+
     copy(Path("LICENSE.md"), root_dir)
     licenses_dir = Path("LICENSES")
     licenses_dest_dir = root_dir / "LICENSES"


### PR DESCRIPTION
People tend to rename the SDK etc and so it helps to have
this file so they know what version they're on.

Also fixes the README for the current layout of the SDK.