### PR TITLE
Change default MR page size behaviour

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -704,7 +704,7 @@ It supports the following attributes:
 
 * `name`: A unique name for the memory region
 * `size`: Size of the memory region in bytes (must be a multiple of the page size)
-* `page_size`: (optional) Size of the pages used in the memory region; must be a supported page size if provided. Defaults to the smallest page size for the target architecture.
+* `page_size`: (optional) Size of the pages used in the memory region; must be a supported page size if provided. Defaults to the largest page size for the target architecture that the memory region is aligned to.
 * `phys_addr`: (optional) The physical address for the start of the memory region (must be a multiple of the page size).
 
 The `memory_region` element does not support any child elements.

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -725,8 +725,8 @@ impl SysMemoryRegion {
         let page_size = if let Some(xml_page_size) = node.attribute("page_size") {
             sdf_parse_number(xml_page_size, node)?
         } else {
-            // Default to the minimum page size
-            config.page_sizes()[0]
+            // Default to the largest page size that will not waste any memory.
+            config.optimal_page_size(size)
         };
 
         let page_size_valid = config.page_sizes().contains(&page_size);

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -80,6 +80,19 @@ impl Config {
         }
     }
 
+    // Given the size of a memory region, returns the 'most optimal'
+    // page size for the platform based on the alignment of the size.
+    pub fn optimal_page_size(&self, size: u64) -> u64 {
+        let page_sizes = self.page_sizes();
+        for i in (0..page_sizes.len()).rev() {
+            if size % page_sizes[i] == 0 {
+                return page_sizes[i];
+            }
+        }
+
+        panic!("Internal error: size is not aligned to minimum page size");
+    }
+
     pub fn pd_stack_top(&self) -> u64 {
         self.user_top()
     }


### PR DESCRIPTION
Before this patch, we would default to the platform's smallest page size if it is not explicitly set on a memory region.

However, I have noticed that users of Microkit (including myself) often forget that you can specify the page size of memory region yourself and so if you have a very large memory region, it is much more efficient to use say, 2MB pages, instead of 4K pages.

From this experience, I believe that it is worthwhile to change the default behaviour to select the larget possible page size for the memory region that does not lead to any memory waste. For example, if you have a 4MB sized MR, 2MB page sizes would be used. If you have a 4.1MB sized MR, 4K page sizes would be used.

I cannot think of any reasonable use-case with Microkit currently where people would be relying on this implicit default behaviour.