### PR TITLE
tool: fix defaulting to largest page size

### DIFF
--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -1481,7 +1481,7 @@ fn build_system(
         if let Some(mut phys_addr) = mr.phys_addr {
             for _ in 0..mr.page_count {
                 fixed_pages.push((phys_addr, mr));
-                phys_addr += mr.page_bytes();
+                phys_addr += mr.page_size_bytes();
             }
         }
     }
@@ -1648,7 +1648,7 @@ fn build_system(
                 let mut vaddr = map.vaddr;
                 for _ in 0..mr.page_count {
                     vaddrs.push((vaddr, mr.page_size));
-                    vaddr += mr.page_bytes();
+                    vaddr += mr.page_size_bytes();
                 }
             }
         }
@@ -1708,7 +1708,7 @@ fn build_system(
             let mut vaddr = map.vaddr;
             for _ in 0..mr.page_count {
                 vaddrs.push((vaddr, mr.page_size));
-                vaddr += mr.page_bytes();
+                vaddr += mr.page_size_bytes();
             }
         }
 
@@ -1946,7 +1946,7 @@ fn build_system(
                     rights,
                     attrs,
                     mr_pages[mr].len() as u64,
-                    mr.page_bytes(),
+                    mr.page_size_bytes(),
                 ));
 
                 for idx in 0..mr_pages[mr].len() {
@@ -2032,7 +2032,7 @@ fn build_system(
                 rights,
                 attrs,
                 mr_pages[mr].len() as u64,
-                mr.page_bytes(),
+                mr.page_size_bytes(),
             ));
 
             for idx in 0..mr_pages[mr].len() {

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -80,19 +80,6 @@ impl Config {
         }
     }
 
-    // Given the size of a memory region, returns the 'most optimal'
-    // page size for the platform based on the alignment of the size.
-    pub fn optimal_page_size(&self, size: u64) -> u64 {
-        let page_sizes = self.page_sizes();
-        for i in (0..page_sizes.len()).rev() {
-            if size % page_sizes[i] == 0 {
-                return page_sizes[i];
-            }
-        }
-
-        panic!("Internal error: size is not aligned to minimum page size");
-    }
-
     pub fn pd_stack_top(&self) -> u64 {
         self.user_top()
     }


### PR DESCRIPTION
d7e63d56a911434f6012f14882e8df1a392cfd0f did not consider that the alignment of the memory region in all its mappings matters as well.

Closes https://github.com/seL4/microkit/issues/243.