### PR TITLE
Added support for Ariane (CVA6) on Digilent Genesys 2 [riscv]

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ board/$board/$config/elf/monitor.elf
 
 The currently supported boards are:
 
+* ariane
 * imx8mm_evk
 * imx8mp_evk
 * imx8mq_evk

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -242,6 +242,18 @@ SUPPORTED_BOARDS = (
             "KernelRiscvExtF": True,
         },
     ),
+    BoardInfo(
+        name="ariane",
+        arch=KernelArch.RISCV64,
+        gcc_cpu=None,
+        loader_link_address=0x90000000,
+        kernel_options={
+            "KernelIsMCS": True,
+            "KernelPlatform": "ariane",
+            "KernelRiscvExtD": True,
+            "KernelRiscvExtF": True,
+        },
+    ),
 )
 
 SUPPORTED_CONFIGS = (

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -951,6 +951,26 @@ You can see that when using the `go` command, U-Boot is
 To avoid this behaviour, the call to `armv8_switch_to_el1` should be replaced with
 `armv8_switch_to_el2` in this `do_go_exec` function.
 
+## Ariane (CVA6)
+
+Initial support is available for the CVA6 (formerly Ariane) core design
+on the Digilent Genesys2 board. CVA6 is an open-source RISC-V (rv64i) processor.
+
+Microkit support expects that a compatible RISC-V SBI (e.g OpenSBI) has executed before
+jumping to the beginning of the loader image.
+
+Note that the loader link address is 0x90000000 and this is where the binary must
+be located and where OpenSBI (or U-Boot) should begin execution.
+
+You may compile OpenSBI with the Microkit image as a payload, or alternately install
+OpenSBI (with U-Boot optionally) to the SD card.
+
+If you are booting from U-Boot, use the following command to start the system image:
+    => go 0x90000000
+
+Note that the OpenSBI version from the CVA6 SDK at the time of writing has issues when
+booting. It is recommended to use the mainline OpenSBI.
+
 ## Adding Platform Support
 
 The following section is a guide for adding support for a new platform to Microkit.

--- a/example/ariane/hello/Makefile
+++ b/example/ariane/hello/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+ifeq ($(strip $(BUILD_DIR)),)
+$(error BUILD_DIR must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_CONFIG)),)
+$(error MICROKIT_CONFIG must be specified)
+endif
+
+TOOLCHAIN := riscv64-unknown-elf
+
+CC := $(TOOLCHAIN)-gcc
+LD := $(TOOLCHAIN)-ld
+AS := $(TOOLCHAIN)-as
+MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+
+HELLO_OBJS := hello.o
+
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+
+IMAGES := hello.elf
+CFLAGS := -mstrict-align -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include -march=rv64imafdc_zicsr_zifencei -mabi=lp64d
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := -lmicrokit -Tmicrokit.ld
+
+IMAGE_FILE = $(BUILD_DIR)/loader.img
+REPORT_FILE = $(BUILD_DIR)/report.txt
+
+all: $(IMAGE_FILE)
+
+$(BUILD_DIR)/%.o: %.c Makefile
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD_DIR)/hello.elf: $(addprefix $(BUILD_DIR)/, $(HELLO_OBJS))
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+$(IMAGE_FILE) $(REPORT_FILE): $(addprefix $(BUILD_DIR)/, $(IMAGES)) hello.system
+	$(MICROKIT_TOOL) hello.system --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)

--- a/example/ariane/hello/hello.c
+++ b/example/ariane/hello/hello.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <stdint.h>
+#include <microkit.h>
+
+void init(void)
+{
+    microkit_dbg_puts("hello, world\n");
+}
+
+void notified(microkit_channel ch)
+{
+}

--- a/example/ariane/hello/hello.system
+++ b/example/ariane/hello/hello.system
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2024, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="hello" priority="254">
+        <program_image path="hello.elf" />
+    </protection_domain>
+</system>


### PR DESCRIPTION
This pull request adds initial support for the CVA6 (formerly Ariane, still known as Ariane in seL4) on the Digilent Genesys 2 FPGA board. It is an open-source RISC-V processor core implementing rv64i.

This change depends on an associated kernel change to re-enable the PLIC, currently in a PR [here](https://github.com/seL4/seL4/pull/1341).