### PR TITLE
Fix examples for channel PPC change

### DIFF
--- a/example/imx8mm_evk/passive_server/passive_server.system
+++ b/example/imx8mm_evk/passive_server/passive_server.system
@@ -5,7 +5,7 @@
  SPDX-License-Identifier: BSD-2-Clause
 -->
 <system>
-    <protection_domain name="server" priority="100" pp="true" passive="true">
+    <protection_domain name="server" priority="100" passive="true">
         <program_image path="server.elf" />
     </protection_domain>
 
@@ -15,7 +15,7 @@
 
     <channel>
         <end pd="server" id="0" />
-        <end pd="client" id="0" />
+        <end pd="client" id="0" pp="true" />
     </channel>
 
 </system>

--- a/example/tqma8xqp1gb/ethernet/ethernet.system
+++ b/example/tqma8xqp1gb/ethernet/ethernet.system
@@ -44,7 +44,7 @@
 
     <memory_region name="eth_clk" size="0x1_000" phys_addr="0x5b200000" />
 
-    <protection_domain name="gpt" priority="254" pp="true">
+    <protection_domain name="gpt" priority="254">
         <program_image path="gpt.elf" />
         <map mr="lsio_gpt0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
         <map mr="lsio_gpt0_clk" vaddr="0x2_200_000" perms="rw" cached="false" setvar_vaddr="gpt_regs_clk" />
@@ -96,7 +96,7 @@
 
     <channel>
         <end pd="gpt" id="1" />
-        <end pd="pass" id="0" />
+        <end pd="pass" id="0" pp="true" />
     </channel>
 
     <channel>


### PR DESCRIPTION
4574734febed447825756b8618948a731187c7cd changes the SDF for PPCs to be described on a per-channel basis. This patch just updates the examples to adhere to the current SDF.