### PR TITLE
monitor: report potential stack overflows

### DIFF
--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -94,6 +94,9 @@ seL4_Word tcbs[MAX_TCBS];
 seL4_Word scheduling_contexts[MAX_TCBS];
 seL4_Word notification_caps[MAX_TCBS];
 
+/* For reporting potential stack overflows, keep track of the stack regions for each PD. */
+seL4_Word pd_stack_addrs[MAX_PDS];
+
 struct region {
     uintptr_t paddr;
     uintptr_t size_bits;
@@ -915,6 +918,12 @@ static void monitor(void)
 #else
 #error "Unknown architecture to print a VM fault for"
 #endif
+
+            seL4_Word fault_addr = seL4_GetMR(seL4_VMFault_Addr);
+            seL4_Word stack_addr = pd_stack_addrs[badge];
+            if (fault_addr < stack_addr && fault_addr >= stack_addr - 0x1000) {
+                puts("MON|ERROR: potential stack overflow, fault address within one page outside of stack region\n");
+            }
 
             break;
         }

--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -181,6 +181,19 @@ pub unsafe fn bytes_to_struct<T>(bytes: &[u8]) -> &T {
     &body[0]
 }
 
+/// Serialise an array of u64 to a Vector of bytes. Pads the Vector of bytes
+/// such that the first entry is empty.
+pub fn monitor_serialise_u64_vec(vec: &[u64]) -> Vec<u8> {
+    let mut bytes = vec![0; (1 + vec.len()) * 8];
+    for (i, value) in vec.iter().enumerate() {
+        let start = (i + 1) * 8;
+        let end = start + 8;
+        bytes[start..end].copy_from_slice(&value.to_le_bytes());
+    }
+
+    bytes
+}
+
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.


### PR DESCRIPTION
Still not 100% ideal as sometimes stack overflows occur multiple pages out-of-bounds of the stack region, but this should be able to catch some of them and save time debugging.