### PR TITLE
monitor: fix patched variables to not be static

### DIFF
--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -85,9 +85,9 @@ seL4_IPCBuffer *__sel4_ipc_buffer;
 
 char _stack[4096];
 
-static char pd_names[MAX_PDS][MAX_NAME_LEN];
+char pd_names[MAX_PDS][MAX_NAME_LEN];
 seL4_Word pd_names_len;
-static char vm_names[MAX_VMS][MAX_NAME_LEN] __attribute__((unused));
+char vm_names[MAX_VMS][MAX_NAME_LEN] __attribute__((unused));
 seL4_Word vm_names_len;
 
 seL4_Word fault_ep;


### PR DESCRIPTION
These need to be visible in the final object and hence should not be static.

This caused an issue with 9a8aba7106a411a1e81df7858ce7a1fc5c26c931 when building in release mode since vm_names is only used in debug mode and so the compiler was (understandably) optimising it out.