### PR TITLE
tool: improve emulation of kernel boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Please clone seL4 from:
 
 The correct branch to use is `microkit`.
 
-Testing has been performed using commit `0383d0f4686e06c96dd8a47f7dc469ca4d9c83b8`.
+Testing has been performed using commit `9919e7db30d68d48c43262acd59caa3e1bdf941c`.
 
 ## Building the SDK
 

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -459,6 +459,12 @@ def build_sel4(
             copy(p, dest)
             dest.chmod(0o744)
 
+    platform_gen = sel4_build_dir / "gen_headers" / "plat" / "machine" / "platform_gen.json"
+    dest = root_dir / "board" / board.name / config.name / "platform_gen.json"
+    dest.unlink(missing_ok=True)
+    copy(platform_gen, dest)
+    dest.chmod(0o744)
+
     gen_config_path = sel4_install_dir / "libsel4/include/kernel/gen_config.json"
     with open(gen_config_path, "r") as f:
         gen_config = json.load(f)

--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 roxmltree = "0.19.0"
-serde = "1.0.203"
+serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 
 [profile.release]

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -5,6 +5,7 @@
 //
 
 use crate::UntypedObject;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 
@@ -16,6 +17,18 @@ pub struct BootInfo {
     pub page_cap_count: u64,
     pub untyped_objects: Vec<UntypedObject>,
     pub first_available_cap: u64,
+}
+
+#[derive(Deserialize)]
+pub struct PlatformConfigRegion {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Deserialize)]
+pub struct PlatformConfig {
+    pub devices: Vec<PlatformConfigRegion>,
+    pub memory: Vec<PlatformConfigRegion>,
 }
 
 /// Represents an allocated kernel object.
@@ -57,6 +70,8 @@ pub struct Config {
     /// RISC-V specific, what kind of virtual memory system (e.g Sv39)
     pub riscv_pt_levels: Option<RiscvVirtualMemory>,
     pub invocations_labels: serde_json::Value,
+    pub device_regions: Vec<PlatformConfigRegion>,
+    pub normal_regions: Vec<PlatformConfigRegion>,
 }
 
 impl Config {

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -24,6 +24,8 @@ const DEFAULT_KERNEL_CONFIG: sel4::Config = sel4::Config {
     riscv_pt_levels: None,
     // Not necessary for SDF parsing
     invocations_labels: json!(null),
+    device_regions: vec![],
+    normal_regions: vec![],
 };
 
 fn check_error(test_name: &str, expected_err: &str) {


### PR DESCRIPTION
One of the things the tool has to do is emulate the kernel boot process, this involves getting a layout of all memory and putting into two categories, 'device' memory and 'normal' memory as defined by the kernel.

The way we do this currently is by looking at certain symbols in the kernel ELF that encode this information. This doesn't work well when the compiler decides to optimise that symbol out and instead embed the information directly into where it's being used in the kernel code.

So, instead we use the `platform_gen.json` file that gets generated by the kernel build system to get the same information.

There should be no difference at all in terms of what the tool actually spits out at the end, it just means that the process of doing this emulation is less fragile.

Closes https://github.com/seL4/microkit/issues/35.

Depends on https://github.com/seL4/seL4/pull/1390 first.