### PR TITLE
loader: fix qemu GIC addresses

### DIFF
--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -32,8 +32,8 @@ _Static_assert(sizeof(uintptr_t) == 8 || sizeof(uintptr_t) == 4, "Expect uintptr
 #define GICD_BASE 0x00F9010000UL
 #define GICC_BASE 0x00F9020000UL
 #elif defined(BOARD_qemu_virt_aarch64)
-#define GICD_BASE 0x8010000UL
-#define GICC_BASE 0x8020000UL
+#define GICD_BASE 0x8000000UL
+#define GICC_BASE 0x8010000UL
 #endif
 
 #define REGION_TYPE_DATA 1
@@ -620,7 +620,7 @@ static void configure_gicv2(void)
      * must be set appropriately. Only interrupts with priorities less
      * than this mask will interrupt the CPU.
      *
-     * seL4 (effectively) sets intererupts to priority 0x80, so it is
+     * seL4 (effectively) sets interrupts to priority 0x80, so it is
      * important to make sure this is greater than 0x80.
      */
     *((volatile uint32_t *)(GICC_BASE + 0x4)) = 0xf0;


### PR DESCRIPTION
Running qemu with -d guest_errors would previously print out

    LDR|INFO: Setting all interrupts to Group 1
    LDR|INFO: GICv2 ITLinesNumber: 0x00000000
    gic_cpu_write: Bad offset 80
    gicv2m_write: Bad offset 4

The first write is supposed to be into the GIC_DIST region, then the second into the GIC_CPU region. Cross referencing to QEMU [1], the GIC addresses in loader.c are incorrect. Now microkit prints:

    LDR|INFO: Setting all interrupts to Group 1
    LDR|INFO: GICv2 ITLinesNumber: 0x00000008

The generated seL4 devices_gen.h from the DTS is correct, this is purely a microkit issue.

[1]: https://github.com/qemu/qemu/blame/de278e54/hw/arm/virt.c#L164-L165