### PR TITLE
libmicrokit: more error reporting

### DIFF
--- a/libmicrokit/src/dbg.c
+++ b/libmicrokit/src/dbg.c
@@ -27,6 +27,19 @@ microkit_dbg_puts(const char *s)
     }
 }
 
+void
+microkit_dbg_put8(seL4_Uint8 x)
+{
+    char tmp[4];
+    unsigned i = 3;
+    tmp[3] = 0;
+    do {
+        seL4_Uint8 c = x % 10;
+        tmp[--i] = '0' + c;
+        x /= 10;
+    } while (x);
+    microkit_dbg_puts(&tmp[i]);
+}
 
 void
 __assert_fail(const char  *str, const char *file, int line, const char *function)

--- a/libmicrokit/src/dbg.c
+++ b/libmicrokit/src/dbg.c
@@ -8,8 +8,7 @@
 #define __thread
 #include <sel4/sel4.h>
 
-void
-microkit_dbg_putc(int c)
+void microkit_dbg_putc(int c)
 {
 #if defined(CONFIG_PRINTING)
     seL4_DebugPutChar(c);
@@ -18,8 +17,7 @@ microkit_dbg_putc(int c)
 
 
 
-void
-microkit_dbg_puts(const char *s)
+void microkit_dbg_puts(const char *s)
 {
     while (*s) {
         microkit_dbg_putc(*s);
@@ -27,8 +25,7 @@ microkit_dbg_puts(const char *s)
     }
 }
 
-void
-microkit_dbg_put8(seL4_Uint8 x)
+void microkit_dbg_put8(seL4_Uint8 x)
 {
     char tmp[4];
     unsigned i = 3;
@@ -41,8 +38,7 @@ microkit_dbg_put8(seL4_Uint8 x)
     microkit_dbg_puts(&tmp[i]);
 }
 
-void
-__assert_fail(const char  *str, const char *file, int line, const char *function)
+void __assert_fail(const char  *str, const char *file, int line, const char *function)
 {
     microkit_dbg_puts("assert failed: ");
     microkit_dbg_puts(str);

--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -28,6 +28,10 @@ seL4_Bool microkit_have_signal = seL4_False;
 seL4_CPtr microkit_signal_cap;
 seL4_MessageInfo_t microkit_signal_msg;
 
+seL4_Word microkit_irqs;
+seL4_Word microkit_notifications;
+seL4_Word microkit_pps;
+
 extern seL4_IPCBuffer __sel4_ipc_buffer_obj;
 
 seL4_IPCBuffer *__sel4_ipc_buffer = &__sel4_ipc_buffer_obj;

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -326,6 +326,15 @@ impl ProtectionDomain {
             })
     }
 
+    pub fn irq_bits(&self) -> u64 {
+        let mut irqs = 0;
+        for irq in &self.irqs {
+            irqs |= 1 << irq.id;
+        }
+
+        irqs
+    }
+
     fn from_xml(
         config: &Config,
         xml_sdf: &XmlSystemDescription,


### PR DESCRIPTION
This patch adds error reporting for libmicrokit APIs that make seL4 system calls that do not have an error return value and so the user does not know what went wrong. There is an error message from the kernel, but it refers to cap numbers which a Microkit user would not understand.

Closes https://github.com/seL4/microkit/issues/174.