### PR TITLE
tool: improve error checking and error reporting for allocations

### DIFF
--- a/tool/microkit/src/util.rs
+++ b/tool/microkit/src/util.rs
@@ -102,10 +102,7 @@ pub fn human_size_strict(size: u64) -> (String, &'static str) {
                 let (d_count, extra) = divmod(size, base);
                 count = d_count;
                 if extra != 0 {
-                    panic!(
-                        "size 0x{:x} is not a multiple of standard power-of-two",
-                        size
-                    );
+                    return (format!("{:.2}", size as f64 / base as f64), label);
                 }
             } else {
                 count = size;


### PR DESCRIPTION
This adds much better error reporting when allocation fails due to a user-error or we have genuinely run out of memory.

The main thing next is to improve the allocator so that we can better utilise the untypeds. There's a couple things it does not that are inefficient but at least now we know when and why an allocation fails.

Closes https://github.com/seL4/microkit/issues/253.
Closes https://github.com/seL4/microkit/issues/250.