### PR TITLE
tool: detect overlaps between user-specified maps and generated maps

### DIFF
--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -90,6 +90,13 @@ pub struct SysMap {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum SysMemoryRegionKind {
+    User,
+    Elf,
+    Stack,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SysMemoryRegion {
     pub name: String,
     pub size: u64,
@@ -97,6 +104,10 @@ pub struct SysMemoryRegion {
     pub page_count: u64,
     pub phys_addr: Option<u64>,
     pub text_pos: Option<roxmltree::TextPos>,
+    /// For error reporting is useful to know whether the MR was created
+    /// due to the user's SDF or created by the tool for setting up the
+    /// stack, ELF, etc.
+    pub kind: SysMemoryRegionKind,
 }
 
 impl SysMemoryRegion {
@@ -837,6 +848,7 @@ impl SysMemoryRegion {
             page_count,
             phys_addr,
             text_pos: Some(xml_sdf.doc.text_pos_at(node.range().start)),
+            kind: SysMemoryRegionKind::User,
         })
     }
 }


### PR DESCRIPTION
A PD will have two sets of mappings in addition to what the user has specified:
1. Mappings for the ELF
2. Mapping(s) for the stack region

Previously, it was possible to accidentally create an overlapping between a user-specified mapping a mapping generated by the tool automatically.

On ARM, this is quite subtle as seL4 allows overwriting existing mappings resulting in no obvious error when this happens.

On RISC-V, this leads to an error upon booting due to seL4 *not* allowing overwriting existing mappings with unmapping first.