### PR TITLE
loader: cleanup uart_init, do it for QEMU virt AArch64

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ This release contains various bug fixes. It does not include any new features.
 * Fixed a regression introduced in 2.0.0 when using channel numbers greater than 32.
 * Fixed building SDK on Linux AArch64 hosts.
 * Fixed loader output to always output return character before newline.
+* Fixed loader to initialise UART for QEMU virt AArch64 to silence warnings
+  when using `-d guest_errors`.
 * Report error when user-specified PD mappings overlap with it's own ELF
   or stack region.
 * Included kernel bug-fix that prevented Raspberry Pi 4B booting correctly.


### PR DESCRIPTION
QEMU virt AArch64 won't have U-Boot to initialise the UART for us. QEMU doesn't care and will happily output to the UART even if it's disabled, however if you add `-d guest_errors` to your QEMU invocation, you will get a bunch of QEMU complaints saying you are outputting to the UART while it is disabled. This will fix that.