### PR TITLE
Enable "KernelAllowSMCCalls" by default on ARM

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -93,6 +93,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -107,6 +108,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -120,6 +122,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -133,6 +136,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -146,6 +150,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -159,6 +164,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -172,6 +178,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -185,6 +192,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -201,6 +209,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmExportPTMRUser": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -227,7 +236,8 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
-            "RPI4_MEMORY": 1024
+            "RPI4_MEMORY": 1024,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(
@@ -241,6 +251,7 @@ SUPPORTED_BOARDS = (
             "KernelArmExportPCNTUser": True,
             "KernelArmHypervisorSupport": True,
             "KernelArmVtimerUpdateVOffset": False,
+            "KernelAllowSMCCalls": True,
         },
     ),
     BoardInfo(

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -635,13 +635,14 @@ The list of registers is defined by the enum `seL4_VCPUReg` in the seL4 source c
 
 ## `void microkit_arm_smc_call(seL4_ARM_SMCContext *args, seL4_ARM_SMCContext *response)`
 
-This API is available only on ARM and only when seL4 has been configured to enable the
-`KernelAllowSMCCalls` option.
-
 The API takes in arguments for a Secure Monitor Call which will be performed by seL4. Any
 response values will be placed into the `response` structure.
 
 The `seL4_ARM_SMCContext` structure contains fields for registers x0 to x7.
+
+Note that this API is only available when the PD making the call has been configured to
+have SMC enabled in the SDF. Note that when the kernel makes the actual SMC, it cannot
+pre-empt the Secure Monito rand therefore any kernel WCET properties are no longer guaranted.
 
 # System Description File {#sysdesc}
 
@@ -671,7 +672,7 @@ It supports the following attributes:
 * `passive`: (optional) Indicates that the protection domain will be passive and thus have its scheduling context removed after initialisation; defaults to false.
 * `stack_size`: (optional) Number of bytes that will be used for the PD's stack.
   Must be be between 4KiB and 16MiB and be 4K page-aligned. Defaults to 4KiB.
-* `smc`: (optional, only on ARM) Allow the PD to give an SMC call for the kernel to perform. Only available when the kernel has been configured with `KernelAllowSMCCalls`. Defaults to false.
+* `smc`: (optional, only on ARM) Allow the PD to give an SMC call for the kernel to perform.. Defaults to false.
 
 Additionally, it supports the following child elements:
 


### PR DESCRIPTION
Previously I did not turn this option on by default because I thought it would make the kernel proofs not apply anymore. In reality this is only true really when a user makes use of the SMC feature. Most users probably will never have to enable it and the ones that that do will no longer have to patch Microkit to enable it.

I've added a warning about using SMC calls in the manual to make users aware of the implications of using this feature.