### PR TITLE
use the initial task untypes for no kernel patch

### DIFF
--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -64,8 +64,6 @@ struct loader_data {
     uintptr_t ui_p_reg_end;
     uintptr_t pv_offset;
     uintptr_t v_entry;
-    uintptr_t extra_device_addr_p;
-    uintptr_t extra_device_size;
 
     uintptr_t num_regions;
     struct region regions[];
@@ -77,9 +75,7 @@ typedef void (*sel4_entry)(
     intptr_t pv_offset,
     uintptr_t v_entry,
     uintptr_t dtb_addr_p,
-    uintptr_t dtb_size,
-    uintptr_t extra_device_addr_p,
-    uintptr_t extra_device_size
+    uintptr_t dtb_size
 );
 
 static void *memcpy(void *dst, const void *src, size_t sz)
@@ -650,9 +646,7 @@ static void start_kernel(void)
         loader_data->pv_offset,
         loader_data->v_entry,
         0,
-        0,
-        loader_data->extra_device_addr_p,
-        loader_data->extra_device_size
+        0
     );
 }
 

--- a/monitor/src/debug.c
+++ b/monitor/src/debug.c
@@ -95,6 +95,25 @@ void dump_bootinfo(seL4_BootInfo *bi)
     puthex64(bi->extraBIPages.end - 1);
     puts("\n");
 
+#if 0
+    for (i = bi->userImageFrames.start; i < bi->userImageFrames.end; i++) {
+        // seL4_DebugCapIdentify(i);
+        // puts("userImageFramesList[");
+        // puthex32(i);
+        // puts("]        = slot: ");
+        // puthex32(bi->userImageFrames.start + i);
+        // puts(", paddr: ");
+        // puthex64(bi->untypedList[i].paddr);
+        // puts(" - ");
+        // puthex64(bi->untypedList[i].paddr + (1UL << bi->untypedList[i].sizeBits));
+        // puts(" (");
+        // puts(bi->untypedList[i].isDevice ? "device" : "normal");
+        // puts(") bits: ");
+        // puthex32(bi->untypedList[i].sizeBits);
+        // puts("\n");
+    }
+#endif
+
 #if 1
     for (i = 0; i < bi->untyped.end - bi->untyped.start; i++) {
         puts("untypedList[");

--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -116,7 +116,7 @@ seL4_Word bootstrap_invocation_count;
 seL4_Word bootstrap_invocation_data[BOOTSTRAP_INVOCATION_DATA_SIZE];
 
 seL4_Word system_invocation_count;
-seL4_Word *system_invocation_data = (void *)0x80000000;
+seL4_Word *system_invocation_data;
 
 struct untyped_info untyped_info;
 

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -92,6 +92,7 @@ pub struct SysMap {
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum SysMemoryRegionKind {
     User,
+    // This one is special and is allocated from the existing frames in the initial task
     Elf,
     Stack,
 }

--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -14,7 +14,7 @@ pub struct BootInfo {
     pub fixed_cap_count: u64,
     pub sched_control_cap: u64,
     pub paging_cap_count: u64,
-    pub page_cap_count: u64,
+    pub user_image_frames: Vec<Object>,
     pub untyped_objects: Vec<UntypedObject>,
     pub first_available_cap: u64,
 }
@@ -40,7 +40,7 @@ pub struct PlatformConfig {
 /// The cap_address refers to a cap address that addresses this cap.
 /// The cap_address is is intended to be valid within the context of the
 /// initial task.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Object {
     /// Type of kernel object
     pub object_type: ObjectType,


### PR DESCRIPTION
Previously, microkit used a kernel patch which added two extra parameters to
the seL4 kernel entry code: `extra_device_addr_p` and `extra_device_size`. This
allowed for microkit to pass the protection domains ELFs and system invocation
data to the initial task without the data being zeroed by seL4 upon an Untyped
Retype invocation. This was done by making it appear as extra device untypes.

That had several downsides. For one, having a kernel patch is not a great
situation to live in. Furthermore, on certain platforms, e.g. RISC-V SMP, it
would be impossible to add these two extra parameters as it would require extra
C-ABI registers which don't exist.

Instead, what this patch does, is pass the extra data as part of the initial
task region. This is fine, as it was *already* contiguous with the initial task
(monitor) ELF file; being present in memory just before it.

What this looks like from the initial task's perspective is that it gets
capabilities to Frames in the seL4_BootInfo data. These frames are for the
initial task's memory. As they are already frame objects, we don't have to do
untype retypes for these objects. As they are already mapped into the initial
task memory, we also don't have to create page tables mappings via the monitor
bootstrap invocations.

Fixes #52 


---

- [ ] Can we verify that the initial task frames are for the correct physical addresses (i.e. that they match what we expected?). I had an off-by-1 bug when developing which took a while to figure out; I used an seL4 patch that made DebugCapIdentify print out the `cap_getAddr` value but that's not viable in general.
- [ ] Does the code structure make sense? I don't know if the way that I wrote the allocation of the frames makes sense.
- [x] Test all the sDDF examples as a regression test