### PR TITLE
Increase default PD stack size to 0x2000

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -671,7 +671,7 @@ It supports the following attributes:
 * `period`: (optional) The PD's period in microseconds; must not be smaller than the budget; defaults to the budget.
 * `passive`: (optional) Indicates that the protection domain will be passive and thus have its scheduling context removed after initialisation; defaults to false.
 * `stack_size`: (optional) Number of bytes that will be used for the PD's stack.
-  Must be be between 4KiB and 16MiB and be 4K page-aligned. Defaults to 4KiB.
+  Must be be between 4KiB and 16MiB and be 4K page-aligned. Defaults to 8KiB.
 * `smc`: (optional, only on ARM) Allow the PD to give an SMC call for the kernel to perform.. Defaults to false.
 
 Additionally, it supports the following child elements:

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -37,8 +37,8 @@ const PD_MAX_PRIORITY: u8 = 254;
 /// In microseconds
 const BUDGET_DEFAULT: u64 = 1000;
 
-/// Default to a stack size of a single page
-const PD_DEFAULT_STACK_SIZE: u64 = 0x1000;
+/// Default to a stack size of 8KiB
+const PD_DEFAULT_STACK_SIZE: u64 = 0x2000;
 const PD_MIN_STACK_SIZE: u64 = 0x1000;
 const PD_MAX_STACK_SIZE: u64 = 1024 * 1024 * 16;
 

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -527,7 +527,7 @@ mod system {
     fn test_map_too_high() {
         check_error(
             "sys_map_too_high.system",
-            "Error: vaddr (0x1000000000000000) must be less than 0xfffffff000 on element 'map'",
+            "Error: vaddr (0x1000000000000000) must be less than 0xffffffe000 on element 'map'",
         )
     }
 


### PR DESCRIPTION
From 4KiB to 8KiB. The motivation for this is that while a lot of the PDs that I have dealt with are fine with 4KiB, when developing I use UBSAN which tends to increase stack usage a lot.

Given the small memory footprint (< 50KiB last time I checked) of PDs, I do not think it is an issue to increase the stack size.

As always, memory constrained users could manually set the stack size to 4KiB.