### PR TITLE
Added builds for extra rpi4B models

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -221,6 +221,36 @@ SUPPORTED_BOARDS = (
         } | DEFAULT_KERNEL_OPTIONS_AARCH64,
     ),
     BoardInfo(
+        name="rpi4b_2gb",
+        arch=KernelArch.AARCH64,
+        gcc_cpu="cortex-a72",
+        loader_link_address=0x10000000,
+        kernel_options={
+            "KernelPlatform": "bcm2711",
+            "RPI4_MEMORY": 2048,
+        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+    ),
+    BoardInfo(
+        name="rpi4b_4gb",
+        arch=KernelArch.AARCH64,
+        gcc_cpu="cortex-a72",
+        loader_link_address=0x10000000,
+        kernel_options={
+            "KernelPlatform": "bcm2711",
+            "RPI4_MEMORY": 4096,
+        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+    ),
+    BoardInfo(
+        name="rpi4b_8gb",
+        arch=KernelArch.AARCH64,
+        gcc_cpu="cortex-a72",
+        loader_link_address=0x10000000,
+        kernel_options={
+            "KernelPlatform": "bcm2711",
+            "RPI4_MEMORY": 8192,
+        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+    ),
+    BoardInfo(
         name="rockpro64",
         arch=KernelArch.AARCH64,
         gcc_cpu="cortex-a53",

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -785,6 +785,9 @@ The currently supported platforms are:
 * qemu_virt_riscv64
 * rockpro64
 * rpi4b_1gb
+* rpi4b_2gb
+* rpi4b_4gb
+* rpi4b_8gb
 * star64
 * tqma8xqp1gb
 * ultra96v2
@@ -974,9 +977,14 @@ You can find more about the QEMU virt platform in the
 ## Raspberry Pi 4B {#rpi4b_1gb}
 
 Support is available for the Raspberry Pi 4 Model B. There are multiple models of the
-Raspberry Pi 4B that have different amounts of RAM, we target the 1GB model in Microkit.
-If you require more than 1GB, please file an issue or pull request to add support for
-models with larger amounts of memory.
+Raspberry Pi 4B that have different amounts of RAM, we have support for the 1GB,
+2GB, 4GB and 8GB models. Because the amount of RAM must be known statically by
+seL4, the Microkit board names differ for each model:
+
+* `rpi4b_1gb` for 1GB of RAM.
+* `rpi4b_2gb` for 2GB of RAM.
+* `rpi4b_4gb` for 4GB of RAM.
+* `rpi4b_8gb` for 8GB of RAM.
 
 For initial board setup, please see the instructions on the
 [seL4 website](https://docs.sel4.systems/Hardware/Rpi4.html).

--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -278,7 +278,7 @@ static void putc(uint8_t ch)
     *UART_REG(PL011_UARTDR) = ch;
 }
 
-#elif defined(BOARD_rpi4b_1gb)
+#elif defined(BOARD_rpi4b_1gb) || defined(BOARD_rpi4b_2gb) || defined(BOARD_rpi4b_4gb) || defined(BOARD_rpi4b_8gb)
 #define UART_BASE 0xfe215040
 #define MU_IO 0x00
 #define MU_LSR 0x14

--- a/platforms.yml
+++ b/platforms.yml
@@ -32,6 +32,15 @@ platforms:
   - name: rpi4b_1gb
     cmake_plat: rpi4
     since: 2.0.0
+  - name: rpi4b_2gb
+    cmake_plat: rpi4
+    since: 2.0.1
+  - name: rpi4b_4gb
+    cmake_plat: rpi4
+    since: 2.0.1
+  - name: rpi4b_8gb
+    cmake_plat: rpi4
+    since: 2.0.1
   - name: imx8mm_evk
     cmake_plat: imx8mm-evk
     since: 1.3.0


### PR DESCRIPTION
This PR adds Microkit builds for 2gb, 4gb and 8gb versions of the rpi4B.

All rpi4B models have same mini-UART MMIO layout, so we use the same code in loader.c.
Builds successfully on Ubuntu using nix.