### PR TITLE
loader: force strict alignment

### DIFF
--- a/loader/Makefile
+++ b/loader/Makefile
@@ -40,7 +40,7 @@ $(error PRINTING must be specified)
 endif
 
 ifeq ($(ARCH),aarch64)
-	CFLAGS_AARCH64 := -DPHYSICAL_ADDRESS_BITS=$(PHYSICAL_ADDRESS_BITS) -mcpu=$(GCC_CPU) -mgeneral-regs-only
+	CFLAGS_AARCH64 := -DPHYSICAL_ADDRESS_BITS=$(PHYSICAL_ADDRESS_BITS) -mcpu=$(GCC_CPU) -mgeneral-regs-only -mstrict-align
 	CFLAGS_ARCH := $(CFLAGS_AARCH64) -DARCH_aarch64
 	ASM_FLAGS_ARCH := -DPHYSICAL_ADDRESS_BITS=$(PHYSICAL_ADDRESS_BITS) -mcpu=$(GCC_CPU)
 	ARCH_DIR := aarch64


### PR DESCRIPTION
It appears that in QEMU SCTLR_EL2.A (Alignment Check Enable) is off by default, and certain code patterns will cause unaligned accesses in e.g. puthex32() which uses a stack-allocated char[].

Forcing -mstrict-align means we should always generate code that respects the alignment requirements. We could have instead set the A bit in EL2, but this is just easier.

Also, we don't appear to have an EL2 fault handler in the loader, so these faults just silently crash the loader.