### PR TITLE
tool: use rust-lld for more targets

### DIFF
--- a/tool/microkit/.cargo/config.toml
+++ b/tool/microkit/.cargo/config.toml
@@ -3,3 +3,6 @@
 
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-Clinker=rust-lld"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-Clinker=rust-lld"]


### PR DESCRIPTION
Necessary to make macOS -> Linux cross-compilation actually possible without even more dependencies such as a C toolchain.