### PR TITLE
Added support for serengeti

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -341,6 +341,17 @@ SUPPORTED_BOARDS = (
         } | DEFAULT_KERNEL_OPTIONS_RISCV64,
     ),
     BoardInfo(
+        name="serengeti",
+        arch=KernelArch.RISCV64,
+        gcc_cpu=None,
+        loader_link_address=0x90000000,
+        kernel_options={
+            "KernelPlatform": "cheshire",
+            "KernelRiscvExtD": True,
+            "KernelRiscvExtF": True,
+        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+    ),
+    BoardInfo(
         name="x86_64_generic",
         arch=KernelArch.X86_64,
         gcc_cpu="generic",

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -853,6 +853,7 @@ The currently supported platforms are:
 * rpi4b_2gb
 * rpi4b_4gb
 * rpi4b_8gb
+* serengeti
 * star64
 * tqma8xqp1gb
 * ultra96v2
@@ -978,6 +979,11 @@ The HardKernel Odroid-C4 is an ARM SBC based on the Amlogic Meson S905X3 system-
 Microkit produces a raw binary file, so when using U-Boot you must execute the image using:
 
     => go 0x20000000
+
+## Serengeti {#serengeti}
+
+Serengeti is a superset of [Cheshire](#cheshire) and has no build differences when compared
+to Cheshire. Please see [Cheshire](#cheshire) for instructions.
 
 ## SiFive Premier P550 {#hifive_p550}
 

--- a/platforms.yml
+++ b/platforms.yml
@@ -38,6 +38,9 @@ platforms:
   - name: cheshire
     cmake_plat: cheshire
     since: 2.0.0
+  - name: serengeti
+    cmake_plat: serengeti
+    since: dev
   - name: rockpro64
     cmake_plat: rockpro64
     since: 2.0.0


### PR DESCRIPTION
This PR adds support for [serengeti](https://github.com/au-ts/serengeti), a variant of the Cheshire SoC with additional peripherals and features intended to run LionsOS.