### PR TITLE
Pin Rust toolchain

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -33,10 +33,6 @@ jobs:
             path: seL4
       - name: Install SDK dependencies
         run: |
-          rustup target add x86_64-unknown-linux-musl
-          rustup component add rust-src --toolchain stable-x86_64-unknown-linux-gnu
-          rustup target add aarch64-unknown-linux-musl
-          rustup component add rust-src --toolchain stable-aarch64-unknown-linux-musl
           sudo apt update
           sudo apt install software-properties-common
           sudo add-apt-repository ppa:deadsnakes/ppa

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -760,12 +760,16 @@ def build_initialiser(
     component_build_dir = build_dir / board.name / config.name / component_name
     component_build_dir.mkdir(exist_ok=True, parents=True)
 
+    toolchain_setup = "cd tool/microkit && rustup toolchain install && cd ../../"
+
     if custom_rust_sel4_dir is None:
         capdl_init_elf = component_build_dir / "bin" / "sel4-capdl-initializer.elf"
         cmd = f"""
+            {toolchain_setup} && \
             RUSTC_BOOTSTRAP=1 \
-            RUST_TARGET_PATH={rust_target_path} SEL4_PREFIX={sel4_src_dir.absolute()} \
-            cargo install {cargo_cross_options} \
+            RUST_TARGET_PATH={rust_target_path} \
+            SEL4_PREFIX={sel4_src_dir.absolute()} \
+            cargo +1.90.0 install {cargo_cross_options} \
             --target {cargo_target} \
             --locked \
             --git https://github.com/au-ts/rust-seL4 --branch capdl_dev sel4-capdl-initializer --rev 118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80 \
@@ -775,8 +779,9 @@ def build_initialiser(
     else:
         capdl_init_elf = custom_rust_sel4_dir / "target" / cargo_target / "release" / "sel4-capdl-initializer.elf"
         cmd = f"""
+            {toolchain_setup} && /
             cd {custom_rust_sel4_dir} && SEL4_PREFIX={sel4_src_dir.absolute()} \
-            cargo build {cargo_cross_options} --target {cargo_target} \
+            cargo +1.90.0 build {cargo_cross_options} --target {cargo_target} \
             --release -p sel4-capdl-initializer
         """
 

--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1753671061,
-        "narHash": "sha256-IU4eBWfe9h2QejJYST+EAlhg8a1H6mh9gbcmWgZ2/mQ=",
+        "lastModified": 1762310305,
+        "narHash": "sha256-EW7xlGJnCW3mKujn/F8me52NXB4nBtabArsRNwehtHM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "40065d17ee4dbec3ded8ca61236132aede843fab",
+        "rev": "4e8e5dfb8e649d3e05d9a173ce9a9cb0498e89c2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,22 +49,7 @@
           ps.setuptools
         ]);
 
-        microkitToolToml = nixpkgs.lib.trivial.importTOML ./tool/microkit/Cargo.toml;
-        microkitToolVersion = microkitToolToml.package.rust-version;
-
-        # Unfortunately Cargo does not support all targets by default so for cross-compiling
-        # we must explicitly add certain targets.
-        rustAdditionalTargets = {
-          aarch64-darwin = [ "x86_64-apple-darwin" ];
-          x86_64-darwin = [ "aarch64-apple-darwin" ];
-          x86_64-linux = [];
-          aarch64-linux = [];
-        }.${system} or (throw "Unsupported system: ${system}");
-
-        rustTool = pkgs.rust-bin.stable.${microkitToolVersion}.default.override {
-          extensions = [ "rust-src" ];
-          targets = [ pkgs.pkgsStatic.hostPlatform.rust.rustcTarget ] ++ rustAdditionalTargets;
-        };
+        rustTool = pkgs.rust-bin.fromRustupToolchainFile ./tool/microkit/rust-toolchain.toml;
       in
       {
         # for `nix fmt`

--- a/tool/microkit/rust-toolchain.toml
+++ b/tool/microkit/rust-toolchain.toml
@@ -1,0 +1,10 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+[toolchain]
+channel = "1.90.0"
+components = [ "rustfmt", "rust-src", "rustc-dev", "llvm-tools-preview", "clippy" ]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "aarch64-apple-darwin"]


### PR DESCRIPTION
Before 9d6b4e09663d4192b00d1c219d28d2b299659d55, we used Rust for the Microkit tool. Since that commit, we now rely on Rust for a runtime component as well, the capDL initialiser as part of the rust-sel4 project.

This use of Rust is quite different to the tool, in that it relies on various unstable features of Rust in order to make use of a custom Rust language runtime. At the time of writing, this makes it unrealistic to use only stabilised features of Rust.

These unstable features are subject to change anytime, which means that allowing users to build the SDK from source with any toolchain has lead to various issues and will likely lead to more as more versions of Rust are released. Not pinning a toolchain was realistic before, because the Microkit tool only made use of stable Rust features.

The Rust eco-system makes use of the rust-toolchain.toml to handle this situation as it allows for pinning the default toolchain and automatically donwload it when trying to compile.

The main issue with this approach is it involves more downloading, especially as all the targets you want to support must be in the 'targets' field from what I understand. This is especially annoying as it means that you have to specify all the targets you *might* want to compile for rather than the ones you actually care about. For example, the CI compiles from a Linux host for x86-64/aarch64 Linux and from a macOS host for x86-64/aarch64 macOS, but you cannot express this kind of situation in the rust-toolchain.toml. This means everyone has to download 4 toolchains because there's 4 targets that we can possibly compile for.

This situation mainly exists due to complexity involved for using the Rust toolchain and the fact that the components and the targets cannot just be one binary you donwload unlike other compilers/toolchains.