### PR TITLE
Update rust-sel4 version

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -768,7 +768,7 @@ def build_initialiser(
             cargo install {cargo_cross_options} \
             --target {cargo_target} \
             --locked \
-            --git https://github.com/au-ts/rust-seL4 --branch capdl_dev sel4-capdl-initializer --rev 118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80 \
+            --git https://github.com/au-ts/rust-seL4 --branch capdl_dev sel4-capdl-initializer --rev 0186e53991b48118b39d9a048c526baabdf6f5d4 \
             --target-dir {rust_target_dir} \
             --root {component_build_dir}
         """

--- a/tool/microkit/Cargo.lock
+++ b/tool/microkit/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sel4-capdl-initializer-types"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-seL4?rev=118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80#118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80"
+source = "git+https://github.com/au-ts/rust-seL4?rev=0186e53991b48118b39d9a048c526baabdf6f5d4#0186e53991b48118b39d9a048c526baabdf6f5d4"
 dependencies = [
  "cfg-if",
  "miniz_oxide",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types-derive"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-seL4?rev=118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80#118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80"
+source = "git+https://github.com/au-ts/rust-seL4?rev=0186e53991b48118b39d9a048c526baabdf6f5d4#0186e53991b48118b39d9a048c526baabdf6f5d4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -19,7 +19,7 @@ roxmltree = "0.19.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.117"
 postcard = { version = "1.0.2", default-features = false, features = ["alloc"] }
-sel4-capdl-initializer-types = { git = "https://github.com/au-ts/rust-seL4", rev = "118c9cd67d3a7c95431a0aeb08d8ce8692ab9d80", features = ["alloc", "serde", "deflate", "std"] }
+sel4-capdl-initializer-types = { git = "https://github.com/au-ts/rust-seL4", rev = "0186e53991b48118b39d9a048c526baabdf6f5d4", features = ["alloc", "serde", "deflate", "std"] }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Include a commit to fix to have the initialiser to use cached mappings when it maps in frames for it to fill out itself.

This caused a regression with ARM platforms and simple Microkit examples on hardware where the mismatch between the non-cached mapping of the initiliaser and other cached mappings that exist.