### PR TITLE
tool: increase heap memory for initialiser

### DIFF
--- a/tool/microkit/src/capdl/initialiser.rs
+++ b/tool/microkit/src/capdl/initialiser.rs
@@ -14,7 +14,7 @@ use crate::{serialise_ut, UntypedObject};
 // The capDL initialiser heap size is calculated by:
 // (spec size * multiplier) + INITIALISER_HEAP_ADD_ON_CONSTANT
 pub const DEFAULT_INITIALISER_HEAP_MULTIPLIER: f64 = 2.0;
-const INITIALISER_HEAP_ADD_ON_CONSTANT: u64 = 16 * 4096;
+const INITIALISER_HEAP_ADD_ON_CONSTANT: u64 = 64 * 4096;
 // Page size used for allocating the spec and heap segments.
 pub const INITIALISER_GRANULE_SIZE: PageSize = PageSize::Small;
 


### PR DESCRIPTION
This is kind of a band-aid and doesn't fix the root problem, the current plan is to remove the heap altogether from the initialiser in rust-sel4 which should remove this complexity in the first place.

This caused a regression with release mode builds where the spec is significantly smaller than on debug builds.

The smaller spec caused a much smaller heap since the heap size is dervied from the spec size. This patch increases the minimum heap size regardless of spec size to avoid the initialiser panicing when it runs out of memory.