### PR TITLE
ci: cancel concurrent builds on PRs

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -15,6 +15,13 @@ on:
   push:
     branches: [ "main" ]
 
+# To reduce the load we cancel any older runs of this workflow for the current
+# PR. For deployment to the main branch, the workflow will run on each push,
+# and the `run_id` parameter will prevent cancellation.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_linux:
     name: Build SDK (Linux x86-64, ARM64)


### PR DESCRIPTION
For macOS we use a self-hosted runner that, during lots of development, ends up spending most of its time running the SDK build for broken commits on PRs that have been force-pushed over.

To prevent this, we borrow the strategy from seL4's '.github/workflows/compilation-checks.yml'

to help speed up CI in general. These automatic CI cancellations should only happen on PRs and not on the main branch at all.