### PR TITLE
libmicrokit: ack all IRQs (workaround seL4/#1536)

### DIFF
--- a/libmicrokit/src/main.c
+++ b/libmicrokit/src/main.c
@@ -69,6 +69,23 @@ static void handler_loop(void)
     bool have_reply = false;
     seL4_MessageInfo_t reply_tag;
 
+    /**
+     * Because of https://github.com/seL4/seL4/issues/1536
+     * let's acknowledge all the IRQs after we've started.
+     */
+    {
+        seL4_Word irqs_to_ack = microkit_irqs;
+        unsigned int idx = 0;
+        do {
+            if (irqs_to_ack & 1) {
+                microkit_irq_ack(idx);
+            }
+
+            irqs_to_ack >>= 1;
+            idx++;
+        } while (irqs_to_ack != 0);
+    }
+
     for (;;) {
         seL4_Word badge;
         seL4_MessageInfo_t tag;


### PR DESCRIPTION
There is a subtle race condition in the way that seL4 sets up IRQs: https://github.com/seL4/seL4/issues/1536.

This removes the need for every driver to manually do something equivalent, as we have needed in sDDF.