### PR TITLE
tool: set initialiser log level

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -763,7 +763,7 @@ def build_initialiser(
             cargo install {cargo_cross_options} \
             --target {cargo_target} \
             --locked \
-            --git https://github.com/seL4/rust-seL4 sel4-capdl-initializer --rev 25896f74efb0f97777f7fc705646e2337613f141 \
+            --git https://github.com/seL4/rust-seL4 sel4-capdl-initializer --rev 0ac1c27ee6cb9edac7a1a41a69b0d421e170d6a4 \
             --target-dir {rust_target_dir} \
             --root {component_build_dir}
         """

--- a/tool/microkit/Cargo.lock
+++ b/tool/microkit/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sel4-capdl-initializer-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-seL4?rev=25896f74efb0f97777f7fc705646e2337613f141#25896f74efb0f97777f7fc705646e2337613f141"
+source = "git+https://github.com/seL4/rust-seL4?rev=0ac1c27ee6cb9edac7a1a41a69b0d421e170d6a4#0ac1c27ee6cb9edac7a1a41a69b0d421e170d6a4"
 dependencies = [
  "miniz_oxide",
  "rkyv",
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types-derive"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-seL4?rev=25896f74efb0f97777f7fc705646e2337613f141#25896f74efb0f97777f7fc705646e2337613f141"
+source = "git+https://github.com/seL4/rust-seL4?rev=0ac1c27ee6cb9edac7a1a41a69b0d421e170d6a4#0ac1c27ee6cb9edac7a1a41a69b0d421e170d6a4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tool/microkit/Cargo.toml
+++ b/tool/microkit/Cargo.toml
@@ -19,7 +19,7 @@ roxmltree = "0.19.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.117"
 rkyv = { version = "0.8.12", default-features = false, features = ["alloc", "bytecheck", "pointer_width_32"] }
-sel4-capdl-initializer-types = { git = "https://github.com/seL4/rust-seL4", rev = "25896f74efb0f97777f7fc705646e2337613f141", features = ["serde", "deflate", "transform"] }
+sel4-capdl-initializer-types = { git = "https://github.com/seL4/rust-seL4", rev = "0ac1c27ee6cb9edac7a1a41a69b0d421e170d6a4", features = ["serde", "deflate", "transform"] }
 
 [profile.release]
 strip = true

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -135,7 +135,8 @@ impl CapDLSpecContainer {
                     end: 0.into(),
                 },
                 untyped_covers: Vec::new(),
-                orig_cap_slots: None,
+                cached_orig_cap_slots: None,
+                log_level: None,
             },
             expected_allocations: HashMap::new(),
         }

--- a/tool/microkit/src/capdl/initialiser.rs
+++ b/tool/microkit/src/capdl/initialiser.rs
@@ -20,10 +20,22 @@ pub struct CapDLInitialiserSpecMetadata {
     pub spec_size: u64,
 }
 
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+pub enum LogLevel {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
+
 pub struct CapDLInitialiser {
     pub elf: ElfFile,
     pub phys_base: Option<u64>,
     pub spec_metadata: Option<CapDLInitialiserSpecMetadata>,
+    /// Log level of initialiser printing in debug mode.
+    pub log_level: LogLevel,
 }
 
 impl CapDLInitialiser {
@@ -32,6 +44,7 @@ impl CapDLInitialiser {
             elf,
             phys_base: None,
             spec_metadata: None,
+            log_level: LogLevel::Info,
         }
     }
 

--- a/tool/microkit/src/capdl/packaging.rs
+++ b/tool/microkit/src/capdl/packaging.rs
@@ -47,6 +47,8 @@ pub fn pack_spec_into_initial_task(
 
     output_spec.cache_orig_cap_slots();
 
+    output_spec.set_log_level(capdl_initialiser.log_level as u8);
+
     let initialiser_payload = output_spec.to_bytes().unwrap();
 
     capdl_initialiser.add_spec(initialiser_payload, embedded_frame_data);


### PR DESCRIPTION
With [1] we can now set the log level for the capDL initialiser from the tool at run-time, instead of having to update the rust-sel4 source code. This should make development much easier.

We could also make this a CLI flag for the Microkit tool but I don't know how useful that is so I'm going to omit this for now.

We make the default log level the same as it was before, so there is no change.

[1]: github.com/seL4/rust-sel4/pull/310