### PR TITLE
(Re-)allow PD priority of 254

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -168,7 +168,7 @@ The overall computational model for a Microkit system is a set of isolated compo
 
 The PD has a number of scheduling attributes that are configured in the system description:
 
-* priority (0 -- 253)
+* priority (0 -- 254)
 * period (microseconds)
 * budget (microseconds)
 * passive (boolean)

--- a/example/ethernet/ethernet.system
+++ b/example/ethernet/ethernet.system
@@ -44,7 +44,7 @@
 
     <memory_region name="eth_clk" size="0x1_000" phys_addr="0x5b200000" />
 
-    <protection_domain name="gpt" priority="253">
+    <protection_domain name="gpt" priority="254">
         <program_image path="gpt.elf" />
         <map mr="lsio_gpt0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
         <map mr="lsio_gpt0_clk" vaddr="0x2_200_000" perms="rw" cached="false" setvar_vaddr="gpt_regs_clk" />

--- a/example/hierarchy/hierarchy.system
+++ b/example/hierarchy/hierarchy.system
@@ -5,9 +5,9 @@
  SPDX-License-Identifier: BSD-2-Clause
 -->
 <system>
-    <protection_domain name="restarter" priority="253">
+    <protection_domain name="restarter" priority="254">
         <program_image path="restarter.elf" />
-        <protection_domain name="crasher" priority="252" id="1">
+        <protection_domain name="crasher" priority="253" id="1">
             <program_image path="crasher.elf" />
         </protection_domain>
         <protection_domain name="hello" priority="1" id="2">

--- a/example/rust/rust.system
+++ b/example/rust/rust.system
@@ -5,7 +5,7 @@
  SPDX-License-Identifier: BSD-2-Clause
 -->
 <system>
-    <protection_domain name="hello" priority="253">
+    <protection_domain name="hello">
         <program_image path="hello.elf" />
     </protection_domain>
 </system>

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -36,8 +36,8 @@ use std::path::{Path, PathBuf};
 const PD_MAX_ID: u64 = 61;
 const VCPU_MAX_ID: u64 = PD_MAX_ID;
 
-pub const MONITOR_PRIORITY: u8 = 254;
-const PD_MAX_PRIORITY: u8 = 253;
+pub const MONITOR_PRIORITY: u8 = 255;
+const PD_MAX_PRIORITY: u8 = 254;
 /// In microseconds
 pub const BUDGET_DEFAULT: u64 = 1000;
 

--- a/tool/microkit/tests/sdf/pd_overlapping_maps.system
+++ b/tool/microkit/tests/sdf/pd_overlapping_maps.system
@@ -7,7 +7,7 @@
 <system>
     <memory_region name="mr1" size="0x1000" />
     <memory_region name="mr2" size="0x1000" />
-    <protection_domain name="hello" priority="253">
+    <protection_domain name="hello" priority="254">
         <program_image path="hello.elf" />
         <map mr="mr1" perms="rw" vaddr="0x1_000_000" />
         <map mr="mr2" perms="rw" vaddr="0x1_000_000" />

--- a/tool/microkit/tests/sdf/vm_missing_mr.system
+++ b/tool/microkit/tests/sdf/vm_missing_mr.system
@@ -5,7 +5,7 @@
  SPDX-License-Identifier: BSD-2-Clause
 -->
 <system>
-    <protection_domain name="hello" priority="253">
+    <protection_domain name="hello" priority="254">
         <program_image path="hello.elf" />
         <virtual_machine name="guest">
             <vcpu id="0" />

--- a/tool/microkit/tests/sdf/vm_overlapping_maps.system
+++ b/tool/microkit/tests/sdf/vm_overlapping_maps.system
@@ -7,7 +7,7 @@
 <system>
     <memory_region name="mr1" size="0x1000" />
     <memory_region name="mr2" size="0x1000" />
-    <protection_domain name="hello" priority="253">
+    <protection_domain name="hello" priority="254">
         <program_image path="hello.elf" />
         <virtual_machine name="guest">
             <vcpu id="0" />


### PR DESCRIPTION
This partially reverts 9d6b4e09663d4192b00d1c219d28d2b299659d55 where the maximum possible priority allowed for a PD was decreased from 254 to 253.

This would break many, many existing Microkit systems and even though it is a trivial fix, I do not think it is worth it for users.

Previously, the monitor was the initial task and so it had the maximum seL4 TCB priority by default, 255.

Because the monitor is a fault handler and it has some other responsibilities such as converting PDs to passive PDs during init, it makes sense for it to be always the highest priority thread in the system. Hence, the maximum priority of any PD was 254, one less than the monitor's priority.

Now with the capDL transition, we have another run-time component involved, the capDL initialiser. It is the initial task now and so it gets the default priority of 255. If the monitor also had a priority of 255 it would mean that some debug printing with the initialiser would get interleaved/messed up which looks unprofessional, so we made the monitor have priority 254 and then all PDs got 253 or lower.

But, that only happens at the very end of the capDL initialiser doing its job so it's probably better to just remove that particular print and instead have the monitor be 255 and so Microkit users don't have to deal with any breaking changes. This print was removed in [1].

[1]: https://github.com/seL4/rust-sel4/pull/310/commits/571093a4aac29210ac3d41ba43ddaa16325f6368.