### PR TITLE
flake.nix: add explicit gnutar

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
             ninja
             libxml2
             qemu
+            gnutar
           ];
 
           # Necessary for Rust bindgen


### PR DESCRIPTION
Had warnings/issues in the past with packing using the BSD macOS tar but then unpacking on Linux using GNU tar. Just make this dependency explicit to avoid issues.