### PR TITLE
flake.nix: add extra rust targets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,8 +55,8 @@
         # Unfortunately Cargo does not support all targets by default so for cross-compiling
         # we must explicitly add certain targets.
         rustAdditionalTargets = {
-          aarch64-darwin = [ "x86_64-apple-darwin" ];
-          x86_64-darwin = [ "aarch64-apple-darwin" ];
+          aarch64-darwin = [ "x86_64-apple-darwin" "x86_64-unknown-linux-musl" "aarch64-unknown-linux-musl" ];
+          x86_64-darwin = [ "aarch64-apple-darwin" "x86_64-unknown-linux-musl" "aarch64-unknown-linux-musl" ];
           x86_64-linux = [];
           aarch64-linux = [];
         }.${system} or (throw "Unsupported system: ${system}");


### PR DESCRIPTION
To allow macOS -> Linux cross-compiling.