### PR TITLE
tool: avoid panic when ELF parsing fails

### DIFF
--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -139,7 +139,14 @@ impl<'a> Loader<'a> {
             unreachable!("internal error: x86_64 does not support creating a loader image");
         }
 
-        let loader_elf = ElfFile::from_path(loader_elf_path).unwrap();
+        let loader_elf = ElfFile::from_path(loader_elf_path).unwrap_or_else(|e| {
+            eprintln!(
+                "ERROR: failed to parse loader ELF ({}): {}",
+                loader_elf_path.display(),
+                e
+            );
+            std::process::exit(1);
+        });
         let sz = loader_elf.word_size;
         let magic = match sz {
             32 => 0x5e14dead,


### PR DESCRIPTION
Cleanup some of the ELF error messages in the process. This is mainly to avoid user's seeing the tool crash when giving an invalid program image which could easily happen by accident.

Closes https://github.com/seL4/microkit/issues/405.