### PR TITLE
Add support for qemu virtual machines using KVM

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -293,6 +293,21 @@ SUPPORTED_BOARDS = (
         } | DEFAULT_KERNEL_OPTIONS_AARCH64,
     ),
     BoardInfo(
+        name="qemu_virt_aarch64_el1",
+        arch=KernelArch.AARCH64,
+        gcc_cpu="cortex-a53",
+        loader_link_address=0x70000000,
+        smp_cores=4,
+        kernel_options={
+            "KernelPlatform": "qemu-arm-virt",
+            "KernelArmHypervisorSupport": False,
+            "QEMU_MEMORY": "2048",
+            # There is no peripheral timer, so we use the ARM
+            # architectural timer
+            "KernelArmExportPTMRUser": True,
+        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+    ),
+    BoardInfo(
         name="qemu_virt_riscv64",
         arch=KernelArch.RISCV64,
         gcc_cpu=None,

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -180,9 +180,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a35",
         loader_link_address=0x90000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "tqma8xqp1gb",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="zcu102",
@@ -190,10 +190,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x40000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "zynqmp",
             "KernelARMPlatform": "zcu102",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="maaxboard",
@@ -201,9 +201,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x50000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "maaxboard",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="imx8mm_evk",
@@ -211,9 +211,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x41000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "imx8mm-evk",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="imx8mp_evk",
@@ -221,9 +221,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x41000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "imx8mp-evk",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="imx8mq_evk",
@@ -231,9 +231,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x41000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "imx8mq-evk",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="imx8mp_iotgate",
@@ -241,11 +241,11 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x50000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "imx8mp-evk",
             "KernelCustomDTS": Path("custom_dts/iot-gate.dts"),
             "KernelCustomDTSOverlay": KernelPath(path="src/plat/imx8m-evk/overlay-imx8mp-evk.dts"),
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="odroidc2",
@@ -253,9 +253,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x20000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "odroidc2",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="odroidc4",
@@ -263,9 +263,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a55",
         loader_link_address=0x20000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "odroidc4",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="ultra96v2",
@@ -273,10 +273,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x40000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "zynqmp",
             "KernelARMPlatform": "ultra96v2",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="qemu_virt_aarch64",
@@ -284,13 +284,13 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x70000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "qemu-arm-virt",
             "QEMU_MEMORY": "2048",
             # There is no peripheral timer, so we use the ARM
             # architectural timer
             "KernelArmExportPTMRUser": True,
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="qemu_virt_aarch64_el1",
@@ -298,14 +298,14 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a53",
         loader_link_address=0x70000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "qemu-arm-virt",
             "KernelArmHypervisorSupport": False,
             "QEMU_MEMORY": "2048",
             # There is no peripheral timer, so we use the ARM
             # architectural timer
             "KernelArmExportPTMRUser": True,
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="qemu_virt_riscv64",
@@ -313,10 +313,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu=None,
         loader_link_address=0x90000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_RISCV64 | {
             "KernelPlatform": "qemu-riscv-virt",
             "QEMU_MEMORY": "2048",
-        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+        },
     ),
     BoardInfo(
         name="rpi4b_1gb",
@@ -324,10 +324,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a72",
         loader_link_address=0x10000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "bcm2711",
             "RPI4_MEMORY": 1024,
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="rpi4b_2gb",
@@ -335,10 +335,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a72",
         loader_link_address=0x10000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "bcm2711",
             "RPI4_MEMORY": 2048,
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="rpi4b_4gb",
@@ -346,10 +346,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a72",
         loader_link_address=0x10000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "bcm2711",
             "RPI4_MEMORY": 4096,
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="rpi4b_8gb",
@@ -357,10 +357,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="cortex-a72",
         loader_link_address=0x10000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "bcm2711",
             "RPI4_MEMORY": 8192,
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="rockpro64",
@@ -370,18 +370,18 @@ SUPPORTED_BOARDS = (
         # ROCKPRO64 has 4 Cortex-A53 cores and 2 Cortex-A72 cores,
         # we always run on the Cortex-A53s.
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "rockpro64",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="rock3b",
         arch=KernelArch.AARCH64,
         gcc_cpu="cortex-a55",
         loader_link_address=0x30000000,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_AARCH64 | {
             "KernelPlatform": "rk3568",
-        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+        },
     ),
     BoardInfo(
         name="hifive_p550",
@@ -389,9 +389,9 @@ SUPPORTED_BOARDS = (
         gcc_cpu=None,
         loader_link_address=0x90000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_RISCV64 | {
             "KernelPlatform": "hifive-p550",
-        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+        },
     ),
     BoardInfo(
         name="star64",
@@ -399,36 +399,36 @@ SUPPORTED_BOARDS = (
         gcc_cpu=None,
         loader_link_address=0x60000000,
         smp_cores=4,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_RISCV64 | {
             "KernelPlatform": "star64",
-        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+        },
     ),
     BoardInfo(
         name="ariane",
         arch=KernelArch.RISCV64,
         gcc_cpu=None,
         loader_link_address=0x90000000,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_RISCV64 | {
             "KernelPlatform": "ariane",
-        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+        },
     ),
     BoardInfo(
         name="cheshire",
         arch=KernelArch.RISCV64,
         gcc_cpu=None,
         loader_link_address=0x90000000,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_RISCV64 | {
             "KernelPlatform": "cheshire",
-        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+        },
     ),
     BoardInfo(
         name="serengeti",
         arch=KernelArch.RISCV64,
         gcc_cpu=None,
         loader_link_address=0x90000000,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_RISCV64 | {
             "KernelPlatform": "cheshire",
-        } | DEFAULT_KERNEL_OPTIONS_RISCV64,
+        },
     ),
     BoardInfo(
         name="x86_64_generic",
@@ -436,10 +436,10 @@ SUPPORTED_BOARDS = (
         gcc_cpu="generic",
         loader_link_address=None,
         smp_cores=DEFAULT_X86_NUM_CPUS,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_X86_64 | {
             "KernelSupportPCID": False,
             "KernelVTX": False,
-        } | DEFAULT_KERNEL_OPTIONS_X86_64,
+        },
     ),
     BoardInfo(
         name="x86_64_generic_vtx",
@@ -447,11 +447,11 @@ SUPPORTED_BOARDS = (
         gcc_cpu="generic",
         loader_link_address=None,
         smp_cores=DEFAULT_X86_NUM_CPUS,
-        kernel_options={
+        kernel_options=DEFAULT_KERNEL_OPTIONS_X86_64 | {
             "KernelSupportPCID": False,
             "KernelVTX": True,
             "KernelX86_64VTX64BitGuests": True,
-        } | DEFAULT_KERNEL_OPTIONS_X86_64,
+        },
     ),
 )
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1111,6 +1111,7 @@ The currently supported platforms are:
 * odroidc2
 * odroidc4
 * qemu_virt_aarch64
+* qemu_virt_aarch64_el1
 * qemu_virt_riscv64
 * rockpro64
 * rock3b
@@ -1290,9 +1291,9 @@ you can load the image and DTB at another address.
 
 ## QEMU virt (AArch64) {#qemu_virt_aarch64}
 
-Support is available for the virtual AArch64 QEMU platform. This is a platform that is not based
-on any specific SoC or hardware platform and is intended for simulating systems for
-development or testing.
+Support is available for the virtual AArch64 QEMU platform running in EL2. This is a
+platform that is not based on any specific SoC or hardware platform and is intended for simulating
+systems for development or testing.
 
 It should be noted that the platform support is configured with 2GB of main memory and the
 Cortex-A53 CPU. seL4 needs to know the memory layout and CPU at build-time so if
@@ -1303,6 +1304,30 @@ You can use the following command to simulate a Microkit system:
 
     $ qemu-system-aarch64 \
         -machine virt,virtualization=on \
+        -cpu cortex-a53 \
+        -nographic \
+        -serial mon:stdio \
+        -device loader,file=[SYSTEM IMAGE],addr=0x70000000,cpu-num=0 \
+        -m size=2G
+
+When using the [SMP configurations](#multicore_config) add the `-smp 4` argument to the QEMU command.
+
+## QEMU virt (AArch64) in EL1 {#qemu_virt_aarch64_el1}
+
+Support is available for the virtual AArch64 QEMU platform running in EL1. This is a platform that
+is not based on any specific SoC or hardware platform and is intended for simulating systems for
+development or testing. This platform differs from the standard QEMU virt platform in that seL4 runs
+in EL1, making it usable on KVM based virtual machines.
+
+It should be noted that the platform support is configured with 2GB of main memory and the
+Cortex-A53 CPU. seL4 needs to know the memory layout and CPU at build-time so if
+you want to change these parameters (e.g to allow more memory), you will have to change the kernel
+options for `qemu_virt_aarch64_el1` in `build_sdk.py`.
+
+You can use the following command to simulate a Microkit system:
+
+    $ qemu-system-aarch64 \
+        -machine virt \
         -cpu cortex-a53 \
         -nographic \
         -serial mon:stdio \

--- a/loader/src/aarch64/init.c
+++ b/loader/src/aarch64/init.c
@@ -25,6 +25,10 @@
 #if defined(CONFIG_PLAT_ZYNQMP_ZCU102) || defined(CONFIG_PLAT_ZYNQMP_ULTRA96V2) || defined(CONFIG_PLAT_QEMU_ARM_VIRT)
 static void configure_gicv2(void)
 {
+    if (current_el() == EL1) {
+        return;
+    }
+
     /* The ZCU102 start in EL3, and then we drop to EL1(NS).
      *
      * The GICv2 supports security extensions (as does the CPU).

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -274,13 +274,6 @@ fn main() -> Result<(), String> {
         std::process::exit(1);
     }
 
-    if let Arch::Aarch64 = kernel_config.arch {
-        assert!(
-            kernel_config.hypervisor,
-            "Microkit tool expects a kernel with hypervisor mode enabled on AArch64."
-        );
-    }
-
     assert!(
         kernel_config.word_size == 64,
         "Microkit tool has various assumptions about the word size being 64-bits."


### PR DESCRIPTION
This PR adds support for running microkit based operating systems using qemu with KVM enabled.

The main issue with the qemu platform with KVM enabled is that it drops the kernel in EL1 instead of the expected EL2. This PR builds a custom kernel for this platform with hypervisor support disabled.

The loader seems to work fine, but jumping to the kernel causes a instruction abort exception. The next is the log:
```
LDR|ERROR: loader trapped exception: Synchronous (Current Exception level with SP_ELx)
    esr_el1: 0x0000000086000004
    ec: 0x00000021 (Instruction Abort taken without a change in Exception level)
    il: 0x0000000000000001
    iss: 0x0000000000000004
    far: 0xffffff8040000000
    reg: 0x00000000: 0x0000000040041000
    reg: 0x00000001: 0x0000000000211274
    reg: 0x00000002: 0x0000000000000000
    reg: 0x00000003: 0x0000000000000000
    reg: 0x00000004: 0xffffff8040000000
    reg: 0x00000005: 0xffffffffffffffff
    reg: 0x00000006: 0x0000000000c5183d
    reg: 0x00000007: 0x0000000000001124
    reg: 0x00000008: 0x0000001485100510
    reg: 0x00000009: 0x0000000000000000
    reg: 0x0000000a: 0x0000000000007830
    reg: 0x0000000b: 0x000000000000000d
    reg: 0x0000000c: 0x0000000000000030
    reg: 0x0000000d: 0x0000000000000030
    reg: 0x0000000e: 0xffffff8040000000
    reg: 0x0000000f: 0x0000000000000030
    reg: 0x00000010: 0x0000000000000030
    reg: 0x00000011: 0x0000000070003298
    reg: 0x00000012: 0x0000000000000000
    reg: 0x00000013: 0x0000000070004000
    reg: 0x00000014: 0x00000000700032f0
    reg: 0x00000015: 0x0000000070003550
    reg: 0x00000016: 0x0000000000000100
    reg: 0x00000017: 0x000000007000c008
    reg: 0x00000018: 0x0000000070003510
    reg: 0x00000019: 0x00000000700034f8
    reg: 0x0000001a: 0x000000007000c008
    reg: 0x0000001b: 0x0000000070005f70
    reg: 0x0000001c: 0x0000000000000000
    reg: 0x0000001d: 0x0000000000000000
    reg: 0x0000001e: 0x0000000000000000
    reg: 0x0000001f: 0x0000000000000000
```