### PR TITLE
monitor: lazy Scheduling Context rebind

### DIFF
--- a/monitor/src/main.c
+++ b/monitor/src/main.c
@@ -733,18 +733,13 @@ static void monitor(void)
 
         if (label == seL4_Fault_NullFault && pd_id < MAX_PDS) {
             /* This is a request from our PD to become passive */
-            err = seL4_SchedContext_UnbindObject(BASE_SCHED_CONTEXT_CAP + pd_id, tcb_cap);
+            err = seL4_SchedContext_Bind(BASE_SCHED_CONTEXT_CAP + pd_id, BASE_NOTIFICATION_CAP + pd_id);
             if (err != seL4_NoError) {
-                puts("MON|ERROR: could not unbind scheduling context from thread control block\n");
+                puts("MON|ERROR: could not bind scheduling context to notification object\n");
             } else {
-                err = seL4_SchedContext_Bind(BASE_SCHED_CONTEXT_CAP + pd_id, BASE_NOTIFICATION_CAP + pd_id);
-                if (err != seL4_NoError) {
-                    puts("MON|ERROR: could not bind scheduling context to notification object\n");
-                } else {
-                    puts("MON|INFO: PD '");
-                    puts(pd_names[pd_id]);
-                    puts("' is now passive!\n");
-                }
+                puts("MON|INFO: PD '");
+                puts(pd_names[pd_id]);
+                puts("' is now passive!\n");
             }
 
             continue;


### PR DESCRIPTION
Applied https://github.com/seL4/seL4/pull/523 to workaround https://github.com/seL4/seL4/issues/1617.

To fix the problem properly this should be performed in the capDL initialiser. But that would take a while to get merged so we will merge this first.

Related: https://github.com/seL4/microkit/issues/91