### PR TITLE
Add stm32mp2 support

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -164,6 +164,17 @@ SUPPORTED_BOARDS = (
         } | DEFAULT_KERNEL_OPTIONS_AARCH64,
     ),
     BoardInfo(
+        name="stm32mp2",
+        arch=KernelArch.AARCH64,
+        gcc_cpu="cortex-a35",
+        loader_link_address=0x88000000,
+        smp_cores=2,
+        kernel_options={
+            "KernelPlatform": "stm32mp2",
+            "KernelARMPlatform": "stm32mp257f-ev1",
+        } | DEFAULT_KERNEL_OPTIONS_AARCH64,
+    ),
+    BoardInfo(
         name="tqma8xqp1gb",
         arch=KernelArch.AARCH64,
         gcc_cpu="cortex-a35",

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1187,6 +1187,7 @@ The currently supported platforms are:
 * rpi4b_8gb
 * serengeti
 * star64
+* stm32mp25_ev1
 * tqma8xqp1gb
 * ultra96v2
 * x86_64_generic
@@ -1555,6 +1556,30 @@ You have to load the binary file into memory and run it:
 ZynqMP> tftpboot 0x40000000 loader.img
 ...
 ZynqMP> go 0x40000000
+```
+
+## STM32MP25 evaluation board {#stm32mp25_ev1}
+
+A newly flashed card will autoboot to Linux. You will need to break (Ctrl+c) or disable autoboot. When entering the U-Boot console, load the Microkit binary image at address 0x88000000:
+
+For initial SD card file system flashing using the initial first-stage boot loader TF-A,
+please see the instructions on the
+[seL4 website](https://docs.sel4.systems/Hardware/MP25EV1.html).
+
+For example, to load the image via the current SD/MMC, identify the partition
+containing the image to be loaded. Assuming it is labelized "bootfs" on the partition 8:
+
+```
+STM32MP> mmc part
+...
+8     0x00002242      0x00034241      "bootfs"
+...
+STM32MP> ext2ls mmc 0:8
+...
+     2759776 loader.img
+...
+STM32MP> ext2load mmc 0:8 0x88000000 loader.img
+STM32MP> go 0x88000000
 ```
 
 ## x86-64 generic {#x86_64_generic}

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1187,7 +1187,7 @@ The currently supported platforms are:
 * rpi4b_8gb
 * serengeti
 * star64
-* stm32mp25_ev1
+* stm32mp2
 * tqma8xqp1gb
 * ultra96v2
 * x86_64_generic
@@ -1558,7 +1558,7 @@ ZynqMP> tftpboot 0x40000000 loader.img
 ZynqMP> go 0x40000000
 ```
 
-## STM32MP25 evaluation board {#stm32mp25_ev1}
+## STM32MP2 {#stm32mp2}
 
 A newly flashed card will autoboot to Linux. You will need to break (Ctrl+c) or disable autoboot. When entering the U-Boot console, load the Microkit binary image at address 0x88000000:
 
@@ -1581,6 +1581,9 @@ STM32MP> ext2ls mmc 0:8
 STM32MP> ext2load mmc 0:8 0x88000000 loader.img
 STM32MP> go 0x88000000
 ```
+
+Note that there is a watchdog enabled by the firmware that will cause the board to reset
+after 30 seconds of runtime.
 
 ## x86-64 generic {#x86_64_generic}
 

--- a/loader/src/aarch64/cpus.c
+++ b/loader/src/aarch64/cpus.c
@@ -63,6 +63,8 @@ static const size_t psci_target_cpus[4] = {0x00, 0x01, 0x02, 0x03};
 static const size_t psci_target_cpus[4] = {0x00, 0x01, 0x02, 0x03};
 #elif defined(CONFIG_PLAT_ROCKPRO64)
 static const size_t psci_target_cpus[4] = {0x00, 0x01, 0x02, 0x03};
+#elif defined(CONFIG_PLAT_STM32MP2)
+static const size_t psci_target_cpus[2] = {0x00, 0x01};
 #elif defined(CONFIG_PLAT_QEMU_ARM_VIRT)
 /* QEMU is special and can have arbitrary numbers of cores */
 // TODO.

--- a/loader/src/uart.c
+++ b/loader/src/uart.c
@@ -188,6 +188,20 @@ void putc(uint8_t ch)
     while ((*UART_REG(ULSR) & ULSR_THRE) == 0);
     *UART_REG(UTHR) = ch;
 }
+#elif defined(CONFIG_PLAT_STM32MP2)
+
+#define UART_BASE     0x400e0000
+#define USART_ISR     0x1c
+#define USART_TDR     0x28
+#define USART_ISR_TXE 0x80
+
+void uart_init(void) {}
+
+void putc(uint8_t ch)
+{
+    while (!(*UART_REG(USART_ISR) & USART_ISR_TXE));
+    *UART_REG(USART_TDR) = ch;
+}
 #elif defined(CONFIG_ARCH_RISCV64)
 
 #include "riscv/sbi.h"

--- a/platforms.yml
+++ b/platforms.yml
@@ -94,3 +94,6 @@ platforms:
   - name: zcu102
     cmake_plat: zcu102
     since: 1.3.0
+  - name: stm32mp2
+    cmake_plat: stm32mp257f-ev1
+    since: dev


### PR DESCRIPTION
Hello,

This is a preliminary version enabling STM32MP2 support for Microkit. I am not yet familiar with all build options, so I may have missed some aspects. The SDK is built as follows:

`python3 build_sdk.py --sel4=$KERNEL --boards=stm32mp2`

It has been tested with the following examples: hello, arm_smc, and passive_server, using this build command:
```
make BUILD_DIR=install_build \
     MICROKIT_BOARD=stm32mp2 \
     MICROKIT_CONFIG=debug \
     MICROKIT_SDK=$MKMP25/release/microkit-sdk-2.1.0-dev
```

Remaining work / questions:

- Test SMP support

A quick look at util64.S:mmu_enable() suggests that we probably need to align with [PR #244](https://github.com/seL4/seL4_tools/pull/244) before testing.  

I have not yet figured out how to enable SMP/PSCI support.
It appears to be enabled when smp_cores is defined in the build script, but I do not see yet execution reaching arm_secondary_cpu_entry_asm()...

- No output in release mode

I am not seeing any UART output in release mode for the examples above.
Is it expected that UART output for PDs is only available in debug builds ?

Thank you for any comment/suggestion