### PR TITLE
Fix IOAPIC Polarity.

### DIFF
--- a/tool/microkit/src/sel4.rs
+++ b/tool/microkit/src/sel4.rs
@@ -573,15 +573,15 @@ impl X86IoapicIrqTrigger {
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum X86IoapicIrqPolarity {
-    LowTriggered = 0,
-    HighTriggered = 1,
+    HighTriggered = 0,
+    LowTriggered = 1,
 }
 
 impl From<u64> for X86IoapicIrqPolarity {
     fn from(item: u64) -> X86IoapicIrqPolarity {
         match item {
-            0 => X86IoapicIrqPolarity::LowTriggered,
-            1 => X86IoapicIrqPolarity::HighTriggered,
+            0 => X86IoapicIrqPolarity::HighTriggered,
+            1 => X86IoapicIrqPolarity::LowTriggered,
             _ => panic!("Unknown x86 IOAPIC IRQ polarity {item:x}"),
         }
     }


### PR DESCRIPTION
The kernel syscall for configuring ioapic pins bitwise or's the polarity value passed in the syscall. If a user wants a low polarity pin they pass the value 1, and if a user wants a high polarity pin they pass 0.
https://github.com/seL4/seL4/blob/82a1a8f48f3d16fecb5398be9200007d59675ff9/src/plat/pc99/machine/ioapic.c#L190-L194

Currently the microkit tool does the opposite i.e. passing 0 for  a low polarity configuration and passing 1 for a high polarity configuration. The enum definition is what this code changes. The value is actually used here:
https://github.com/seL4/microkit/blob/cbc4c9dbba20787badaf90cc852bb18064564d48/tool/microkit/src/capdl/irq.rs#L73-L87