### PR TITLE
loader,smp: Enable caches on all cores for shareability

### DIFF
--- a/loader/src/aarch64/cpus.c
+++ b/loader/src/aarch64/cpus.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "smc.h"
+#include "../arch.h"
 #include "../cpus.h"
 #include "../cutil.h"
 #include "../loader.h"
@@ -110,6 +111,14 @@ void arm_secondary_cpu_entry(int logical_cpu, uint64_t mpidr_el1)
 
     plat_save_hw_id(logical_cpu, mpidr_el1);
 
+    int r = arch_mmu_enable(logical_cpu);
+    if (r != 0) {
+        LDR_PRINT("ERROR", logical_cpu, "failed to enable MMU: ");
+        puthex32(r);
+        puts("\n");
+        goto fail;
+    }
+
     start_kernel(logical_cpu);
 
 fail:
@@ -174,6 +183,10 @@ int plat_start_cpu(int logical_cpu)
     sp[0] = logical_cpu;
     /* zero out what was here before */
     sp[1] = 0;
+
+    /* clean up the cache line containing sp before use by secondary core */
+    asm volatile("dc cvac, %0" :: "r"(sp) : "memory");
+    asm volatile("dsb sy" ::: "memory");
 
     /* Arguments as per 5.1.4 CPU_ON of the PSCI spec.
 

--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -100,15 +100,6 @@ static int print_lock = 0;
 
 void start_kernel(int logical_cpu)
 {
-    LDR_PRINT("INFO", logical_cpu, "enabling MMU\n");
-    int r = arch_mmu_enable(logical_cpu);
-    if (r != 0) {
-        LDR_PRINT("ERROR", logical_cpu, "failed to enable MMU: ");
-        puthex32(r);
-        puts("\n");
-        for (;;) {}
-    }
-
     LDR_PRINT("INFO", logical_cpu, "jumping to kernel\n");
 
 #ifdef CONFIG_PRINTING
@@ -174,6 +165,13 @@ int main(void)
     LDR_PRINT("INFO", 0, "active CPUs to start: ");
     puthex32(plat_get_active_cpus());
     puts("\n");
+
+    r = arch_mmu_enable(0);
+    if (r != 0) {
+        LDR_PRINT("ERROR", 0, "failed to enable MMU: ");
+        puthex32(r);
+        fail();
+    }
 
     for (int cpu = 1; cpu < plat_get_active_cpus(); cpu++) {
         r = plat_start_cpu(cpu);


### PR DESCRIPTION
Hello,

This fixes an SMP boot issue observed on the STM32MP2 platform: core 0 does not start because print_lock is never seen as released by the secondary cores. The issue is related to cachability, which is not yet enabled at this stage.

Ensure all cores are in the same coherency domain before using cached shared data by enable MMU on all cores before using shared datas
Thus moved arch_mmu_enable() out of start_kernel().