### PR TITLE
Enable kernel HardwareDebugAPI for supported platforms.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sel4"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "cfg-if",
  "sel4-config",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "sel4-alloca"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "cfg-if",
 ]
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "sel4-bitfield-ops"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "rustversion",
 ]
@@ -520,12 +520,12 @@ dependencies = [
 [[package]]
 name = "sel4-build-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-capdl-initializer"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "log",
  "rkyv",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "miniz_oxide",
  "rkyv",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types-derive"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "sel4-config"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-data"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "sel4-build-env",
  "sel4-config-types",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "fallible-iterator",
  "proc-macro2",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "serde",
 ]
@@ -607,12 +607,12 @@ dependencies = [
 [[package]]
 name = "sel4-ctors-dtors"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-dlmalloc"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "dlmalloc",
  "lock_api",
@@ -621,22 +621,22 @@ dependencies = [
 [[package]]
 name = "sel4-elf-header"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-immediate-sync-once-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-immutable-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-initialize-tls"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "cfg-if",
  "sel4-alloca",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "sel4-logging"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "lock_api",
  "log",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "sel4-panicking"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "cfg-if",
  "sel4-immediate-sync-once-cell",
@@ -665,12 +665,12 @@ dependencies = [
 [[package]]
 name = "sel4-panicking-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-root-task"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "sel4",
  "sel4-dlmalloc",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "sel4-root-task-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "sel4-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -710,12 +710,12 @@ dependencies = [
 [[package]]
 name = "sel4-stack"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 
 [[package]]
 name = "sel4-sync"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "lock_api",
  "sel4",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "sel4-sys"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=7a2321f2d84310ba7a09fe7f5988e6dcecde3566#7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
 dependencies = [
  "bindgen",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ members = [
 ]
 
 [workspace.dependencies.sel4-capdl-initializer]
-git = "https://github.com/seL4/rust-sel4"
-rev = "7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+git = "https://github.com/au-ts/rust-sel4"
+rev = "9102a134c2b5925d17e021280a3d104e79805221"
 
 [workspace.dependencies.sel4-capdl-initializer-types]
-git = "https://github.com/seL4/rust-sel4"
-rev = "7a2321f2d84310ba7a09fe7f5988e6dcecde3566"
+git = "https://github.com/au-ts/rust-sel4"
+rev = "9102a134c2b5925d17e021280a3d104e79805221"
 
 [profile.release.package.microkit-tool]
 strip = true

--- a/build_sdk.py
+++ b/build_sdk.py
@@ -445,7 +445,14 @@ SUPPORTED_CONFIGS = (
             "KernelPrinting": True,
             "KernelVerificationBuild": False
         },
-        kernel_options_arch={},
+        kernel_options_arch={
+            KernelArch.AARCH64: {
+                "HardwareDebugAPI": True,
+            },
+            KernelArch.X86_64: {
+                "HardwareDebugAPI": True,
+            }
+        },
     ),
     ConfigInfo(
         name="benchmark",


### PR DESCRIPTION
The zynqmp config.cmake has `KernelHardwareDebugAPIUnsupported` on for some reason, so will have to look into that.

RISC-V seems unsupported in general.