### PR TITLE
Loader MMU Cleanups (AArch64)

### DIFF
--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -22,6 +22,12 @@ macro_rules! grab_symbol {
 const PAGE_TABLE_SIZE: usize = 4096;
 
 pub mod aarch64 {
+    //! For AArch64, our page tables can be both Stage 2 (if we run in EL2) or Stage
+    //! 1 (if we run in EL1, for non-hyp seL4). Generally, most attributes of the
+    //! page tables for the features we use are compatible in the layouts between
+    //! the Stage 2 descriptors and the Stage 1 descriptors. When modifying values
+    //! of the descriptors, please ensure that the values are valid for both stages
+    //! of the translation scheme.
     use crate::util::mask;
 
     pub const LVL0_BITS: u64 = 9;
@@ -43,15 +49,64 @@ pub mod aarch64 {
         idx as usize
     }
 
-    /// These match those in util64.S configured in the MAIR register
+    /// The one main difference between the Stage 1 and Stage 2 translation
+    /// tables is that bit[4:2] contains AttrIndex[2:0] (Stage 1) or
+    /// MemAttr[3:0] (Stage 2).
+    /// For Stage 1, the AttrIndex depends on our configured value of `MAIR_EL1`
+    /// done in util64.S.
+    /// For Stage 2, the values are fixed in Table D8-96 "Stage 2 MemAttr[3:0] encoding"
+    #[derive(Copy, Clone)]
+    pub enum MemAttr {
+        Stage1 { attr_index: u64 },
+        Stage2 { mem_attr: u64 },
+    }
 
+    impl MemAttr {
+        pub fn value(&self) -> u64 {
+            match *self {
+                MemAttr::Stage1 { attr_index } => attr_index,
+                MemAttr::Stage2 { mem_attr } => mem_attr,
+            }
+        }
+        pub fn is_normal_cacheable(&self) -> bool {
+            match *self {
+                MemAttr::Stage1 { attr_index } => attr_index == s1_mair_attr_index::MT_NORMAL,
+                MemAttr::Stage2 { mem_attr } => mem_attr == s2_mem_attr::NORMAL_INNER_WBC_OUTER_WBC,
+            }
+        }
+    }
+
+    /// These match those in util64.S configured in the MAIR_EL1 register,
+    /// which also needs to match the values that seL4 uses.
     #[allow(non_upper_case_globals, reason = "matching ARM naming convention")]
-    pub const MT_DEVICE_nGnRnE: u64 = 0;
+    pub mod s1_mair_attr_index {
+        pub const MT_DEVICE_nGnRnE: u64 = 0b000;
+        pub const MT_DEVICE_nGnRE: u64 = 0b001;
+        pub const MT_DEVICE_GRE: u64 = 0b010;
+        pub const MT_NORMAL_NC: u64 = 0b011;
+        pub const MT_NORMAL: u64 = 0b100;
+    }
+
+    /// See fixed values in Table D8-96 "Stage 2 MemAttr[3:0] encoding"
     #[allow(non_upper_case_globals, reason = "matching ARM naming convention")]
-    pub const MT_DEVICE_nGnRE: u64 = 1 << 2;
-    pub const MT_DEVICE_GRE: u64 = 2 << 2;
-    pub const MT_NORMAL_NC: u64 = 3 << 2;
-    pub const MT_NORMAL: u64 = 4 << 2;
+    pub mod s2_mem_attr {
+        pub const DEVICE_nGnRnE: u64 = 0b0000;
+        pub const DEVICE_nGnRE: u64 = 0b0001;
+        pub const DEVICE_nGRE: u64 = 0b0010;
+        pub const DEVICE_GRE: u64 = 0b0011;
+
+        pub const NORMAL_INNER_NC_OUTER_NC: u64 = 0b0101;
+        pub const NORMAL_INNER_WTC_OUTER_NC: u64 = 0b0110;
+        pub const NORMAL_INNER_WBC_OUTER_NC: u64 = 0b0111;
+
+        pub const NORMAL_INNER_NC_OUTER_WTC: u64 = 0b1001;
+        pub const NORMAL_INNER_WTC_OUTER_WTC: u64 = 0b1010;
+        pub const NORMAL_INNER_WBC_OUTER_WTC: u64 = 0b1011;
+
+        pub const NORMAL_INNER_NC_OUTER_WBC: u64 = 0b1101;
+        pub const NORMAL_INNER_WTC_OUTER_WBC: u64 = 0b1110;
+        pub const NORMAL_INNER_WBC_OUTER_WBC: u64 = 0b1111;
+    }
 
     pub mod descriptor_type {
         //! The translation table descriptor formats, as per §D8.3 "Translation
@@ -68,12 +123,11 @@ pub mod aarch64 {
         pub const INVALID: u64 = 0b00;
     }
 
-    // TODO: are we stage 2 or stage 1?
-    // TODO: what is the difference between stage 2 / stage 1??
     pub mod shareability_attributes {
         //! Per §D8.6.2 "Stage 1 Shareability attributes", these contain the
         //! shareability attributes of the descriptor OA for normal-cacheable
-        //! memory.
+        //! memory. These values are the same as in §D8.6.7 "Stage 2 Shareability
+        //! attributes", so we can use the same for both Stage 1 / Stage 2.
 
         /// Non-shareable
         pub const NON_SHAREABLE: u64 = 0b00;
@@ -82,8 +136,6 @@ pub mod aarch64 {
         /// Inner-shareable
         pub const INNER_SHAREABLE: u64 = 0b11;
     }
-
-    // TODO: for PT
 
     /// Per "Figure D8-14 VMSAv8-64 Block descriptor formats" of ARM DDI0487L.b,
     /// subfigure "4KB, 16KB, and 64KB granules, 48-bit OA", the Output address
@@ -104,35 +156,45 @@ pub mod aarch64 {
     /// Per "Table D8-52 Stage 1 VMSAv8-64 Block and Page descriptor fields" and
     /// "Figure D8-14 VMSAv8-64 Block descriptor formats" of ARM DDI0487L.b;
     /// specifically subfigure "4KB, 16KB, and 64KB granules, 48-bit OA"
-    pub fn block_descriptor(level: usize, addr: u64, attr_index: u64) -> u64 {
+    /// Also "Table D8-53 Stage 2 VMSAv8-64 Block and Page descriptor fields"
+    /// for the Stage 2 attributes.
+    pub fn block_descriptor(level: usize, addr: u64, mem_attr: MemAttr) -> u64 {
         // Per Table D8-48, Condition for descriptor_type::BLOCK is level != 3.
         assert!(level != 3);
 
         let upper_attributes: u64 = 0;
 
-        let shareability = if attr_index == MT_NORMAL {
+        let shareability = if mem_attr.is_normal_cacheable() {
             // Match what the seL4 kernel uses for its page tables
             shareability_attributes::INNER_SHAREABLE
         } else {
-            // Per $R_{PYFVQ}$:
+            // Per $R_{PYFVQ}$ (Stage 1) and $R_{RYHCTP}$ (Stage 2):
             // > If a region is mapped as Device memory or Normal Non-cacheable
             // > memory after all enabled translation stages, then the region
             // > has an effective Shareability attribute of Outer Shareable.
+            //
             // We override the value we place in here to OUTER_SHAREABLE to match
-            // how the hardware behaves.
+            // how the hardware behaves. This is not necessary but for clarity.
             shareability_attributes::OUTER_SHAREABLE
         };
 
-        // bit[11] is the not global (nG) field, we leave as 0 (global)
+        // AP[2:1], which we set as 0b00 for read/write access:
+        //   stage 1: 0b00 is {PrivRead, PrivWrite} and we are EL1
+        //   stage 2: 0b00 is RW for EL2 and no perms for EL1.
+        const AP_KERNEL_RW: u64 = 0b00;
+
+        // bit[11] is the not global (nG) field, we leave as 0 (global).
+        //         In Stage2 it is RES0.
         // bit[10] is the access flag; depending on FEAT_HAFDBS, when software
         //         manages the AF memory accesses to the page/block when AF=0
         //         raise an Access Fault; when hardware manages the AF it will
         //         become 1.
         // bit[9:8] is SH[1:0] containing stage 1 shareability attributes
-        // bit[7:6] contains AP[2:1] (FIXME: why is this 0b00????)
+        // bit[7:6] contains AP[2:1]
         // bit[5] is RES0
-        // bit[4:2] contains AttrIndex
-        let lower_attributes: u64 = (1 << 10) | (0b00 << 6) | (shareability << 8) | attr_index;
+        // bit[4:2] contains AttrIndex (Stage 1) or MemAttr (Stage 2)
+        let lower_attributes: u64 =
+            (1 << 10) | (AP_KERNEL_RW << 6) | (shareability << 8) | (mem_attr.value() << 2);
 
         // bits[47:n]
         let output_address: u64 = addr
@@ -156,14 +218,16 @@ pub mod aarch64 {
 
     /// Per "Table D8-52 Stage 1 VMSAv8-64 Block and Page descriptor fields" and
     /// "Figure D8-15 VMSAv8-64 Page descriptor formats" of ARM DDI0487L.b;
-    /// specifically subfigure "4KB granule 48-bit OA"
-    pub fn page_descriptor(addr: u64, attr_index: u64) -> u64 {
+    /// specifically subfigure "4KB granule 48-bit OA".
+    /// Also "Table D8-53 Stage 2 VMSAv8-64 Block and Page descriptor fields"
+    /// for the Stage 2 attributes.
+    pub fn page_descriptor(addr: u64, mem_attr: MemAttr) -> u64 {
         // The main difference between a page descriptor and block descriptor
         // is in the size of the output address (OA) and in the descriptor type.
 
         let upper_attributes: u64 = 0;
 
-        let shareability = if attr_index == MT_NORMAL {
+        let shareability = if mem_attr.is_normal_cacheable() {
             // Match what the seL4 kernel uses for its page tables
             shareability_attributes::INNER_SHAREABLE
         } else {
@@ -176,16 +240,23 @@ pub mod aarch64 {
             shareability_attributes::OUTER_SHAREABLE
         };
 
-        // bit[11] is the not global (nG) field, we leave as 0 (global)
+        // AP[2:1], which we set as 0b00 for read/write access:
+        //   stage 1: 0b00 is {PrivRead, PrivWrite} and we are EL1
+        //   stage 2: 0b00 is RW for EL2 and no perms for EL1.
+        const AP_KERNEL_RW: u64 = 0b00;
+
+        // bit[11] is the not global (nG) field, we leave as 0 (global).
+        //         In Stage2 it is RES0
         // bit[10] is the access flag; depending on FEAT_HAFDBS, when software
         //         manages the AF memory accesses to the page/block when AF=0
         //         raise an Access Fault; when hardware manages the AF it will
         //         become 1.
         // bit[9:8] is SH[1:0] containing stage 1 shareability attributes
-        // bit[7:6] contains AP[2:1] (FIXME: why is this 0b00????)
+        // bit[7:6] contains AP[2:1]
         // bit[5] is RES0
-        // bit[4:2] contains AttrIndex
-        let lower_attributes: u64 = (1 << 10) | (0b00 << 6) | (shareability << 8) | attr_index;
+        // bit[4:2] contains AttrIndex (Stage 1) or MemAttr (Stage 2)
+        let lower_attributes: u64 =
+            (1 << 10) | (AP_KERNEL_RW << 6) | (shareability << 8) | (mem_attr.value() << 2);
 
         // bits[47:12]
         let output_address: u64 = addr & !mask(12);
@@ -665,6 +736,7 @@ impl<'a> Loader<'a> {
     /// Otherwise, the page tables layout from Level 1 downwards are identical
     /// (but not necessarily the layout within the page/table/block descriptors).
     ///
+    /// ```txt
     ///          (256 TiB)
     ///   512 +-- Level 0 --+ 2^48
     ///       |             |
@@ -735,6 +807,7 @@ impl<'a> Loader<'a> {
     ///      i = align_down(loader_start_addr, 1GiB),
     ///      s = align_down(loader_start_addr, 2MiB),
     ///      t = align_up(loader_end_addr, 2MiB),
+    /// ```
     ///
     fn aarch64_setup_pagetables(
         elf: &ElfFile,
@@ -750,6 +823,21 @@ impl<'a> Loader<'a> {
 
         let (loader_start_addr, _) = grab_symbol!(elf, "_loader_start");
         let (loader_end_addr, _) = grab_symbol!(elf, "_loader_end");
+
+        // Stage 1 or 2 depends on hypervisor config. TODO: Vary.
+        let hypervisor = true;
+        #[rustfmt::skip]
+        let memattr_normal = if hypervisor {
+            aarch64::MemAttr::Stage2 { mem_attr: aarch64::s2_mem_attr::NORMAL_INNER_WBC_OUTER_WBC }
+        } else {
+            aarch64::MemAttr::Stage1 { attr_index: aarch64::s1_mair_attr_index::MT_NORMAL }
+        };
+        #[rustfmt::skip]
+        let memattr_device = if hypervisor {
+            aarch64::MemAttr::Stage2 { mem_attr: aarch64::s2_mem_attr::DEVICE_nGnRnE }
+        } else {
+            aarch64::MemAttr::Stage1 { attr_index: aarch64::s1_mair_attr_index::MT_DEVICE_nGnRnE }
+        };
 
         if aarch64::lvl1_index(loader_start_addr) != aarch64::lvl1_index(loader_end_addr) {
             panic!("We only map 1GiB, but loader paddr range covers multiple GiB");
@@ -773,7 +861,7 @@ impl<'a> Loader<'a> {
 
             let lvl1_idx = aarch64::lvl1_index(uart_base);
 
-            let pt_entry = aarch64::block_descriptor(1, uart_base, aarch64::MT_DEVICE_nGnRnE);
+            let pt_entry = aarch64::block_descriptor(1, uart_base, memattr_device);
 
             let start = 8 * lvl1_idx;
             let end = 8 * (lvl1_idx + 1);
@@ -796,7 +884,7 @@ impl<'a> Loader<'a> {
                 ((i - aarch64::lvl2_index(loader_start_addr)) << aarch64::BLOCK_BITS_2MB) as u64;
 
             let pt_entry =
-                aarch64::block_descriptor(2, loader_start_addr + entry_idx, aarch64::MT_DEVICE_nGnRnE);
+                aarch64::block_descriptor(2, loader_start_addr + entry_idx, memattr_device);
 
             let start = 8 * i;
             let end = 8 * (i + 1);
@@ -811,7 +899,7 @@ impl<'a> Loader<'a> {
             assert!(aarch64::lvl2_index(loader_start_addr) != lvl2_idx);
             assert!(aarch64::lvl1_index(loader_start_addr) == aarch64::lvl1_index(0));
 
-            let pt_entry = aarch64::block_descriptor(2, lvl2_idx as u64, aarch64::MT_DEVICE_nGnRnE);
+            let pt_entry = aarch64::block_descriptor(2, lvl2_idx as u64, memattr_device);
 
             let start = 8 * lvl2_idx;
             let end = 8 * (lvl2_idx + 1);
@@ -839,8 +927,7 @@ impl<'a> Loader<'a> {
             let entry_idx: u64 =
                 ((i - aarch64::lvl2_index(first_vaddr)) << aarch64::BLOCK_BITS_2MB) as u64;
 
-            let pt_entry =
-                aarch64::block_descriptor(2, first_paddr + entry_idx, aarch64::MT_NORMAL);
+            let pt_entry = aarch64::block_descriptor(2, first_paddr + entry_idx, memattr_normal);
 
             let start = 8 * i;
             let end = 8 * (i + 1);

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -14,14 +14,12 @@ use std::path::Path;
 
 const PAGE_TABLE_SIZE: usize = 4096;
 
-mod aarch64 {
+pub mod aarch64 {
     use crate::util::mask;
 
-    pub(crate) const BLOCK_BITS_1GB: u64 = 30;
-    pub(crate) const BLOCK_BITS_2MB: u64 = 21;
-    pub(crate) const LVL0_BITS: u64 = 9;
-    pub(crate) const LVL1_BITS: u64 = 9;
-    pub(crate) const LVL2_BITS: u64 = 9;
+    pub const LVL0_BITS: u64 = 9;
+    pub const LVL1_BITS: u64 = 9;
+    pub const LVL2_BITS: u64 = 9;
 
     pub fn lvl0_index(addr: u64) -> usize {
         let idx = (addr >> (BLOCK_BITS_2MB + LVL2_BITS + LVL1_BITS)) & mask(LVL0_BITS);
@@ -36,6 +34,191 @@ mod aarch64 {
     pub fn lvl2_index(addr: u64) -> usize {
         let idx = (addr >> (BLOCK_BITS_2MB)) & mask(LVL2_BITS);
         idx as usize
+    }
+
+    /// These match those in util64.S configured in the MAIR register
+
+    #[allow(non_upper_case_globals, reason = "matching ARM naming convention")]
+    pub const MT_DEVICE_nGnRnE: u64 = 0;
+    #[allow(non_upper_case_globals, reason = "matching ARM naming convention")]
+    pub const MT_DEVICE_nGnRE: u64 = 1 << 2;
+    pub const MT_DEVICE_GRE: u64 = 2 << 2;
+    pub const MT_NORMAL_NC: u64 = 3 << 2;
+    pub const MT_NORMAL: u64 = 4 << 2;
+
+    pub mod descriptor_type {
+        //! The translation table descriptor formats, as per §D8.3 "Translation
+        //! table descriptor formats" of ARM DDI 0487 L.b. Specifically,
+        //! as per "Table D8-48 Determination of descriptor type"
+
+        /// Descriptor type: Table. Condition is lookup level != 3.
+        pub const TABLE: u64 = 0b11;
+        /// Descriptor type: Page. Condition is lookup level == 3.
+        pub const PAGE: u64 = 0b11;
+        /// Descriptor type: Block. Condition is lookup level != 3.
+        pub const BLOCK: u64 = 0b01;
+        /// Descriptor type: Invalid. Strictly speaking bit[1] does not matter.
+        pub const INVALID: u64 = 0b00;
+    }
+
+    // TODO: are we stage 2 or stage 1?
+    // TODO: what is the difference between stage 2 / stage 1??
+    pub mod shareability_attributes {
+        //! Per §D8.6.2 "Stage 1 Shareability attributes", these contain the
+        //! shareability attributes of the descriptor OA for normal-cacheable
+        //! memory.
+
+        /// Non-shareable
+        pub const NON_SHAREABLE: u64 = 0b00;
+        /// Outer-shareable
+        pub const OUTER_SHAREABLE: u64 = 0b10;
+        /// Inner-shareable
+        pub const INNER_SHAREABLE: u64 = 0b11;
+    }
+
+    // TODO: for PT
+
+    /// Per "Figure D8-14 VMSAv8-64 Block descriptor formats" of ARM DDI0487L.b,
+    /// subfigure "4KB, 16KB, and 64KB granules, 48-bit OA", the Output address
+    /// is bits [47:n], and:
+    ///
+    /// > For the 4KB granule size, the level 1 descriptor n is 30,
+    /// > and the level 2 descriptor n is 21.
+    pub const BLOCK_BITS_1GB: u64 = 30;
+
+    /// Per "Figure D8-14 VMSAv8-64 Block descriptor formats" of ARM DDI0487L.b,
+    /// subfigure "4KB, 16KB, and 64KB granules, 48-bit OA", the Output address
+    /// is bits [47:n], and:
+    ///
+    /// > For the 4KB granule size, the level 1 descriptor n is 30,
+    /// > and the level 2 descriptor n is 21.
+    pub const BLOCK_BITS_2MB: u64 = 21;
+
+    /// Per "Table D8-52 Stage 1 VMSAv8-64 Block and Page descriptor fields" and
+    /// "Figure D8-14 VMSAv8-64 Block descriptor formats" of ARM DDI0487L.b;
+    /// specifically subfigure "4KB, 16KB, and 64KB granules, 48-bit OA"
+    pub fn block_descriptor(level: usize, addr: u64, attr_index: u64) -> u64 {
+        // Per Table D8-48, Condition for descriptor_type::BLOCK is level != 3.
+        assert!(level != 3);
+
+        let upper_attributes: u64 = 0;
+
+        let shareability = if attr_index == MT_NORMAL {
+            // Match what the seL4 kernel uses for its page tables
+            shareability_attributes::INNER_SHAREABLE
+        } else {
+            // Per $R_{PYFVQ}$:
+            // > If a region is mapped as Device memory or Normal Non-cacheable
+            // > memory after all enabled translation stages, then the region
+            // > has an effective Shareability attribute of Outer Shareable.
+            // We override the value we place in here to OUTER_SHAREABLE to match
+            // how the hardware behaves.
+            shareability_attributes::OUTER_SHAREABLE
+        };
+
+        // bit[11] is the not global (nG) field, we leave as 0 (global)
+        // bit[10] is the access flag; depending on FEAT_HAFDBS, when software
+        //         manages the AF memory accesses to the page/block when AF=0
+        //         raise an Access Fault; when hardware manages the AF it will
+        //         become 1.
+        // bit[9:8] is SH[1:0] containing stage 1 shareability attributes
+        // bit[7:6] contains AP[2:1] (FIXME: why is this 0b00????)
+        // bit[5] is RES0
+        // bit[4:2] contains AttrIndex
+        let lower_attributes: u64 = (1 << 10) | (0b00 << 6) | (shareability << 8) | attr_index;
+
+        // bits[47:n]
+        let output_address: u64 = addr
+            & !mask(match level {
+                1 => BLOCK_BITS_1GB,
+                2 => BLOCK_BITS_2MB,
+                _ => panic!("unsupported level {level} for block descriptor"),
+            });
+
+        // address must not have bits above 47 set.
+        assert!(addr & mask(48) == addr);
+
+        // bits[63:50] describing the "Upper attributes" are left at 0.
+        // bits[49:48] are RES0
+        // bits[47:n] contain the Output address
+        // bits[n-1:12] are RES0
+        // bits[11:2] contain the "Lower attributes"
+        // bits[1:0] contains the descriptor type
+        upper_attributes | output_address | lower_attributes | descriptor_type::BLOCK
+    }
+
+    /// Per "Table D8-52 Stage 1 VMSAv8-64 Block and Page descriptor fields" and
+    /// "Figure D8-15 VMSAv8-64 Page descriptor formats" of ARM DDI0487L.b;
+    /// specifically subfigure "4KB granule 48-bit OA"
+    pub fn page_descriptor(addr: u64, attr_index: u64) -> u64 {
+        // The main difference between a page descriptor and block descriptor
+        // is in the size of the output address (OA) and in the descriptor type.
+
+        let upper_attributes: u64 = 0;
+
+        let shareability = if attr_index == MT_NORMAL {
+            // Match what the seL4 kernel uses for its page tables
+            shareability_attributes::INNER_SHAREABLE
+        } else {
+            // Per $R_{PYFVQ}$:
+            // > If a region is mapped as Device memory or Normal Non-cacheable
+            // > memory after all enabled translation stages, then the region
+            // > has an effective Shareability attribute of Outer Shareable.
+            // We override the value we place in here to OUTER_SHAREABLE to match
+            // how the hardware behaves.
+            shareability_attributes::OUTER_SHAREABLE
+        };
+
+        // bit[11] is the not global (nG) field, we leave as 0 (global)
+        // bit[10] is the access flag; depending on FEAT_HAFDBS, when software
+        //         manages the AF memory accesses to the page/block when AF=0
+        //         raise an Access Fault; when hardware manages the AF it will
+        //         become 1.
+        // bit[9:8] is SH[1:0] containing stage 1 shareability attributes
+        // bit[7:6] contains AP[2:1] (FIXME: why is this 0b00????)
+        // bit[5] is RES0
+        // bit[4:2] contains AttrIndex
+        let lower_attributes: u64 = (1 << 10) | (0b00 << 6) | (shareability << 8) | attr_index;
+
+        // bits[47:12]
+        let output_address: u64 = addr & !mask(12);
+
+        // address must not have bits above 47 set.
+        assert!(addr & mask(48) == addr);
+
+        // bits[63:50] describing the "Upper attributes" are left at 0.
+        // bits[49:48] are RES0
+        // bits[47:12] contain the Output address
+        // bits[11:2] contain the "Lower attributes"
+        // bits[1:0] contains the descriptor type
+        upper_attributes | output_address | lower_attributes | descriptor_type::PAGE
+    }
+
+    /// Per "Table D8-50 Stage 1 VMSAv8-64 Table descriptor fields" and
+    /// "Figure D8-12 VMSAv8-64 Table descriptor formats" of ARM DDI0487L.b;
+    /// specifically subfigure "4KB, 16KB, and 64KB granules, 48-bit OA"
+    pub fn table_descriptor(addr: u64) -> u64 {
+        // Per Table D8-48, Condition for descriptor_type::TABLE is level != 3.
+
+        // We don't set any of these attributes, most are hardware-feature conditional
+        let attributes: u64 = 0;
+
+        // address must not have bits above 47 or below 12 set
+        assert!(addr & mask(12) == 0x0);
+        assert!(addr & mask(48) == addr);
+
+        let next_level_table_address = addr;
+
+        // bits[63:59] are "Attributes"
+        // bits[58:51] are ignored
+        // bits[50:48] are RES0
+        // bits[47:m] is the next-level table address
+        //  note: here m=12 for 4KB granule
+        // bits[m-1:12] are RES0
+        //  so this doesn't exist for 4KB granule
+        // bits[11:2] are ignored
+        // bits[1:0] contain the descriptor type
+        attributes | next_level_table_address | descriptor_type::TABLE
     }
 }
 
@@ -500,7 +683,10 @@ impl<'a> Loader<'a> {
         }
 
         let mut boot_lvl0_lower: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
-        boot_lvl0_lower[..8].copy_from_slice(&(boot_lvl1_lower_addr | 3).to_le_bytes());
+        {
+            let pt_entry = aarch64::table_descriptor(boot_lvl1_lower_addr);
+            boot_lvl0_lower[..8].copy_from_slice(&pt_entry.to_le_bytes());
+        }
 
         let mut boot_lvl1_lower: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
 
@@ -512,11 +698,9 @@ impl<'a> Loader<'a> {
             let uart_base = u64::from_le_bytes(data[0..8].try_into().unwrap());
 
             let lvl1_idx = aarch64::lvl1_index(uart_base);
-            #[allow(clippy::identity_op)] // keep the (0 << 2) for clarity
-            let pt_entry: u64 = ((lvl1_idx as u64) << aarch64::BLOCK_BITS_1GB) |
-                (1 << 10) | // access flag
-                (0 << 2) | // strongly ordered memory
-                (1 << 0); // 1G block
+
+            let pt_entry = aarch64::block_descriptor(1, uart_base, aarch64::MT_DEVICE_nGnRnE);
+
             let start = 8 * lvl1_idx;
             let end = 8 * (lvl1_idx + 1);
             boot_lvl1_lower[start..end].copy_from_slice(&pt_entry.to_le_bytes());
@@ -525,21 +709,21 @@ impl<'a> Loader<'a> {
         let mut boot_lvl2_lower: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
 
         // 1GB lvl1 Table entry
-        let pt_entry = (boot_lvl2_lower_addr | 3).to_le_bytes();
+        let pt_entry = aarch64::table_descriptor(boot_lvl2_lower_addr);
         let lvl1_idx = aarch64::lvl1_index(start_addr);
         let start = 8 * lvl1_idx;
         let end = 8 * (lvl1_idx + 1);
-        boot_lvl1_lower[start..end].copy_from_slice(&pt_entry);
+        boot_lvl1_lower[start..end].copy_from_slice(&pt_entry.to_le_bytes());
 
         // map the loader 1:1 access into 2MB lvl2 Block entries for a 4KB granule
         let lvl2_idx = aarch64::lvl2_index(start_addr);
         for i in lvl2_idx..=aarch64::lvl2_index(end_addr) {
-            let entry_idx = (i - aarch64::lvl2_index(start_addr)) << aarch64::BLOCK_BITS_2MB;
-            let pt_entry: u64 = (entry_idx as u64 + start_addr) |
-                (1 << 10) | // Access flag
-                (3 << 8) | // Sharable
-                (0 << 2) |
-                (1 << 0); // 2M block
+            let entry_idx: u64 =
+                ((i - aarch64::lvl2_index(start_addr)) << aarch64::BLOCK_BITS_2MB) as u64;
+
+            let pt_entry =
+                aarch64::block_descriptor(2, start_addr + entry_idx, aarch64::MT_DEVICE_nGnRnE);
+
             let start = 8 * i;
             let end = 8 * (i + 1);
             boot_lvl2_lower[start..end].copy_from_slice(&pt_entry.to_le_bytes());
@@ -552,11 +736,9 @@ impl<'a> Loader<'a> {
             // Make sure we don't override the loader mappings done above.
             assert!(aarch64::lvl2_index(start_addr) != lvl2_idx);
             assert!(aarch64::lvl1_index(start_addr) == aarch64::lvl1_index(0));
-            #[allow(clippy::identity_op)] // keep the (0 << 2) for clarity
-            let pt_entry: u64 = ((lvl2_idx as u64) << aarch64::BLOCK_BITS_2MB) |
-                (1 << 10) | // access flag
-                (0 << 2) | // strongly ordered memory
-                (1 << 0); // 2M block
+
+            let pt_entry = aarch64::block_descriptor(2, lvl2_idx as u64, aarch64::MT_DEVICE_nGnRnE);
+
             let start = 8 * lvl2_idx;
             let end = 8 * (lvl2_idx + 1);
             boot_lvl2_lower[start..end].copy_from_slice(&pt_entry.to_le_bytes());
@@ -564,28 +746,28 @@ impl<'a> Loader<'a> {
 
         let boot_lvl0_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
-            let pt_entry = (boot_lvl1_upper_addr | 3).to_le_bytes();
+            let pt_entry = aarch64::table_descriptor(boot_lvl1_upper_addr);
             let idx = aarch64::lvl0_index(first_vaddr);
-            boot_lvl0_lower[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry);
+            boot_lvl0_lower[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry.to_le_bytes());
         }
 
         let mut boot_lvl1_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
-            let pt_entry = (boot_lvl2_upper_addr | 3).to_le_bytes();
+            let pt_entry = aarch64::table_descriptor(boot_lvl2_upper_addr);
             let idx = aarch64::lvl1_index(first_vaddr);
-            boot_lvl1_upper[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry);
+            boot_lvl1_upper[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry.to_le_bytes());
         }
 
         let mut boot_lvl2_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
 
         let lvl2_idx = aarch64::lvl2_index(first_vaddr);
         for i in lvl2_idx..512 {
-            let entry_idx = (i - aarch64::lvl2_index(first_vaddr)) << aarch64::BLOCK_BITS_2MB;
-            let pt_entry: u64 = (entry_idx as u64 + first_paddr) |
-                (1 << 10) | // Access flag
-                (3 << 8) | // Make sure the shareability is the same as the kernel's
-                (4 << 2) | // MT_NORMAL memory
-                (1 << 0); // 2MB block
+            let entry_idx: u64 =
+                ((i - aarch64::lvl2_index(first_vaddr)) << aarch64::BLOCK_BITS_2MB) as u64;
+
+            let pt_entry =
+                aarch64::block_descriptor(2, first_paddr + entry_idx, aarch64::MT_NORMAL);
+
             let start = 8 * i;
             let end = 8 * (i + 1);
             boot_lvl2_upper[start..end].copy_from_slice(&pt_entry.to_le_bytes());

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -647,6 +647,95 @@ impl<'a> Loader<'a> {
         ]
     }
 
+    /// AArch64 loader page tables have two variations:
+    ///  - Loader in EL2, then Stage 2 translations in use, so we have the
+    ///    singular TTBR0_EL2 register containing the Level 0 table;
+    ///    this allows virtual address in the range [0,2^48).
+    ///  - Loader in EL1, then Stage 1 translations are in use, so we have both
+    ///    the TTBR0_EL1 (covering vaddr in range [0,2^48)) and TTBR1_EL2 (
+    ///    (covering vaddr in the range [2^64-2^48,2^64)), and containing
+    ///    the "Level 0 Lower" page table, and "Level 0 Upper" page table
+    ///    physical addresses respectively.
+    ///
+    /// Thus, for EL2 loader, the singular Level 0 page table contains the table
+    /// descriptors for the "Level 1 Upper" and "Level 1 Lower" page tables.
+    /// For the EL1 loader, we instead have two Level 0 page tables, and
+    /// "Level 0 Lower" contains the "Level 1 Lower" descriptor, and "Level 0
+    /// Upper" contains the "Level 1 Upper" descriptor.
+    /// Otherwise, the page tables layout from Level 1 downwards are identical
+    /// (but not necessarily the layout within the page/table/block descriptors).
+    ///
+    ///          (256 TiB)
+    ///   512 +-- Level 0 --+ 2^48
+    ///       |             |
+    ///       |   (empty)   |
+    ///       |             |
+    ///   k+1 +-------------+                 (512 GiB)
+    ///       | Level 1 Upr | ---------->  +-- Level 1 --+
+    ///     k +-------------+              |             |
+    ///       |             |              |   (empty)   |
+    ///       |             |              |             |
+    ///       |             |         l+1  +-------------+                 (1 GiB)
+    ///       |             |              | Level 2 Upr | ----------> +-- Level 2 --+             +-------------+
+    ///       |             |           l  +-------------+             |             | ----------> | 2 MiB block |
+    ///       |             |              |             |         511 |-------------|             +-------------+
+    ///       |             |              |   (empty)   |             |             | ----------> | 2 MiB block |
+    ///       |             |              |             |         510 |-------------|             +-------------+
+    ///       |             |              +-------------+             |             | ----------> | 2 MiB block |
+    ///       |             |                                          |-------------|             +-------------+
+    ///       |   (empty)   |                          Kernel Regions       (...)         (...)         (...)
+    ///       |             |                                          |-------------|             +-------------+
+    ///       |             |                                          |             | ----------> | 2 MiB block |
+    ///       |             |                                        m |-------------|             +-------------+ p
+    ///       |             |                                          |             |
+    ///       |             |                                          |   (empty)   |
+    ///       |             |                                          |             |
+    ///       |             |                                        0 +-------------+
+    ///       |             |
+    ///       |             |
+    ///       |             |
+    ///     1 +-------------+                 (512 GiB)
+    ///       | Level 1 Lwr | ---------->  +-- Level 1 --+
+    ///     0 +-------------+              |             |
+    ///                                    |   (empty)   |
+    ///                                    |             |
+    ///                                u+1 +-------------+             +-------------+
+    ///                                    |  uart_base  | ----------> | 1 GiB block |
+    ///                                  u +-------------+             +-------------+
+    ///                                    |             |
+    ///                                    |   (empty)   |
+    ///                                    |             |
+    ///                               i+1  +-------------+                 (1 GiB)
+    ///                                    | Level 2 Lwr | ----------> +-- Level 2 --+
+    ///                                 i  +-------------+             |             |
+    ///                                    |             |             |   (empty)   |
+    ///                                    |   (empty)   |             |             |
+    ///                                    |             |           t +-------------+             +-------------+
+    ///                                    +-------------+             |             | ----------> | 2 MiB block |
+    ///                                                                |-------------|             +-------------+
+    ///                                                                |             | ----------> | 2 MiB block |
+    ///                                                                |-------------|             +-------------+
+    ///                                                Loader Regions       (...)         (...)         (...)
+    ///                                                                |-------------|             +-------------+
+    ///                                                                |             | ----------> | 2 MiB block |
+    ///                                                                |-------------|             +-------------+
+    ///                                                                |             | ----------> | 2 MiB block |
+    ///                                                              s +-------------+             +-------------+
+    ///                                                                |             |
+    ///                                                                |   (empty)   |
+    ///                                                                |             |
+    ///                                                                +-------------+
+    ///
+    /// Where:
+    ///      k = align_down(kernel_first_vaddr, 512GiB),
+    ///      l = align_down(kernel_first_vaddr, 1GiB),
+    ///      m = align_down(kernel_first_vaddr, 2MiB),
+    ///      p = align_down(kernel_first_paddr, 2MiB),
+    ///      u = align_down(uart_base, 1GiB),
+    ///      i = align_down(loader_start_addr, 1GiB),
+    ///      s = align_down(loader_start_addr, 2MiB),
+    ///      t = align_up(loader_end_addr, 2MiB),
+    ///
     fn aarch64_setup_pagetables(
         elf: &ElfFile,
         first_vaddr: u64,

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -12,6 +12,13 @@ use std::io::{BufWriter, Write};
 use std::ops::Range;
 use std::path::Path;
 
+macro_rules! grab_symbol {
+    ($elf: expr, $symbol_name: literal) => {
+        $elf.find_symbol($symbol_name)
+            .expect(concat!("Could not find '", $symbol_name, "' symbol"))
+    };
+}
+
 const PAGE_TABLE_SIZE: usize = 4096;
 
 pub mod aarch64 {
@@ -580,18 +587,10 @@ impl<'a> Loader<'a> {
         first_vaddr: u64,
         first_paddr: u64,
     ) -> Vec<(u64, u64, [u8; PAGE_TABLE_SIZE])> {
-        let (text_addr, _) = elf
-            .find_symbol("_text")
-            .expect("Could not find 'text' symbol");
-        let (boot_lvl1_pt_addr, boot_lvl1_pt_size) = elf
-            .find_symbol("boot_lvl1_pt")
-            .expect("Could not find 'boot_lvl1_pt' symbol");
-        let (boot_lvl2_pt_addr, boot_lvl2_pt_size) = elf
-            .find_symbol("boot_lvl2_pt")
-            .expect("Could not find 'boot_lvl2_pt' symbol");
-        let (boot_lvl2_pt_elf_addr, boot_lvl2_pt_elf_size) = elf
-            .find_symbol("boot_lvl2_pt_elf")
-            .expect("Could not find 'boot_lvl2_pt_elf' symbol");
+        let (text_addr, _) = grab_symbol!(elf, "_text");
+        let (boot_lvl1_pt_addr, boot_lvl1_pt_size) = grab_symbol!(elf, "boot_lvl1_pt");
+        let (boot_lvl2_pt_addr, boot_lvl2_pt_size) = grab_symbol!(elf, "boot_lvl2_pt");
+        let (boot_lvl2_pt_elf_addr, boot_lvl2_pt_elf_size) = grab_symbol!(elf, "boot_lvl2_pt_elf");
 
         let num_pt_levels = config.riscv_pt_levels.unwrap().levels();
 
@@ -653,32 +652,17 @@ impl<'a> Loader<'a> {
         first_vaddr: u64,
         first_paddr: u64,
     ) -> Vec<(u64, u64, [u8; PAGE_TABLE_SIZE])> {
-        let (boot_lvl1_lower_addr, boot_lvl1_lower_size) = elf
-            .find_symbol("boot_lvl1_lower")
-            .expect("Could not find 'boot_lvl1_lower' symbol");
-        let (boot_lvl1_upper_addr, boot_lvl1_upper_size) = elf
-            .find_symbol("boot_lvl1_upper")
-            .expect("Could not find 'boot_lvl1_upper' symbol");
-        let (boot_lvl2_upper_addr, boot_lvl2_upper_size) = elf
-            .find_symbol("boot_lvl2_upper")
-            .expect("Could not find 'boot_lvl2_upper' symbol");
-        let (boot_lvl0_lower_addr, boot_lvl0_lower_size) = elf
-            .find_symbol("boot_lvl0_lower")
-            .expect("Could not find 'boot_lvl0_lower' symbol");
-        let (boot_lvl0_upper_addr, boot_lvl0_upper_size) = elf
-            .find_symbol("boot_lvl0_upper")
-            .expect("Could not find 'boot_lvl0_upper' symbol");
-        let (boot_lvl2_lower_addr, boot_lvl2_lower_size) = elf
-            .find_symbol("boot_lvl2_lower")
-            .expect("Could not find 'boot_lvl2_lower' symbol");
-        let (start_addr, _) = elf
-            .find_symbol("_loader_start")
-            .expect("Could not find 'loader_start' symbol");
-        let (end_addr, _) = elf
-            .find_symbol("_loader_end")
-            .expect("Could not find 'loader_end' symbol");
+        let (boot_lvl1_lower_addr, boot_lvl1_lower_size) = grab_symbol!(elf, "boot_lvl1_lower");
+        let (boot_lvl1_upper_addr, boot_lvl1_upper_size) = grab_symbol!(elf, "boot_lvl1_upper");
+        let (boot_lvl2_upper_addr, boot_lvl2_upper_size) = grab_symbol!(elf, "boot_lvl2_upper");
+        let (boot_lvl0_lower_addr, boot_lvl0_lower_size) = grab_symbol!(elf, "boot_lvl0_lower");
+        let (boot_lvl0_upper_addr, boot_lvl0_upper_size) = grab_symbol!(elf, "boot_lvl0_upper");
+        let (boot_lvl2_lower_addr, boot_lvl2_lower_size) = grab_symbol!(elf, "boot_lvl2_lower");
 
-        if aarch64::lvl1_index(start_addr) != aarch64::lvl1_index(end_addr) {
+        let (loader_start_addr, _) = grab_symbol!(elf, "_loader_start");
+        let (loader_end_addr, _) = grab_symbol!(elf, "_loader_end");
+
+        if aarch64::lvl1_index(loader_start_addr) != aarch64::lvl1_index(loader_end_addr) {
             panic!("We only map 1GiB, but loader paddr range covers multiple GiB");
         }
 
@@ -691,10 +675,11 @@ impl<'a> Loader<'a> {
         let mut boot_lvl1_lower: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
 
         // map optional UART MMIO in l1 1GB page, only available if CONFIG_PRINTING
-        if let Ok((uart_addr, _)) = elf.find_symbol("uart_addr") {
+        if let Ok((uart_addr, uart_addr_size)) = elf.find_symbol("uart_addr") {
             let data = elf
-                .get_data(uart_addr, 8)
+                .get_data(uart_addr, uart_addr_size)
                 .expect("uart_addr not initialized");
+
             let uart_base = u64::from_le_bytes(data[0..8].try_into().unwrap());
 
             let lvl1_idx = aarch64::lvl1_index(uart_base);
@@ -710,19 +695,19 @@ impl<'a> Loader<'a> {
 
         // 1GB lvl1 Table entry
         let pt_entry = aarch64::table_descriptor(boot_lvl2_lower_addr);
-        let lvl1_idx = aarch64::lvl1_index(start_addr);
+        let lvl1_idx = aarch64::lvl1_index(loader_start_addr);
         let start = 8 * lvl1_idx;
         let end = 8 * (lvl1_idx + 1);
         boot_lvl1_lower[start..end].copy_from_slice(&pt_entry.to_le_bytes());
 
         // map the loader 1:1 access into 2MB lvl2 Block entries for a 4KB granule
-        let lvl2_idx = aarch64::lvl2_index(start_addr);
-        for i in lvl2_idx..=aarch64::lvl2_index(end_addr) {
+        let lvl2_idx = aarch64::lvl2_index(loader_start_addr);
+        for i in lvl2_idx..=aarch64::lvl2_index(loader_end_addr) {
             let entry_idx: u64 =
-                ((i - aarch64::lvl2_index(start_addr)) << aarch64::BLOCK_BITS_2MB) as u64;
+                ((i - aarch64::lvl2_index(loader_start_addr)) << aarch64::BLOCK_BITS_2MB) as u64;
 
             let pt_entry =
-                aarch64::block_descriptor(2, start_addr + entry_idx, aarch64::MT_DEVICE_nGnRnE);
+                aarch64::block_descriptor(2, loader_start_addr + entry_idx, aarch64::MT_DEVICE_nGnRnE);
 
             let start = 8 * i;
             let end = 8 * (i + 1);
@@ -734,8 +719,8 @@ impl<'a> Loader<'a> {
         if elf.find_symbol("cpus_release_addr").is_ok() {
             let lvl2_idx = aarch64::lvl2_index(0);
             // Make sure we don't override the loader mappings done above.
-            assert!(aarch64::lvl2_index(start_addr) != lvl2_idx);
-            assert!(aarch64::lvl1_index(start_addr) == aarch64::lvl1_index(0));
+            assert!(aarch64::lvl2_index(loader_start_addr) != lvl2_idx);
+            assert!(aarch64::lvl1_index(loader_start_addr) == aarch64::lvl1_index(0));
 
             let pt_entry = aarch64::block_descriptor(2, lvl2_idx as u64, aarch64::MT_DEVICE_nGnRnE);
 

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -479,6 +479,7 @@ impl<'a> Loader<'a> {
 
         let pagetable_vars = match config.arch {
             Arch::Aarch64 => Loader::aarch64_setup_pagetables(
+                config,
                 &loader_elf,
                 kernel_first_vaddr,
                 kernel_first_paddr,
@@ -816,6 +817,7 @@ impl<'a> Loader<'a> {
     /// ```
     ///
     fn aarch64_setup_pagetables(
+        config: &Config,
         elf: &ElfFile,
         first_vaddr: u64,
         first_paddr: u64,
@@ -834,16 +836,15 @@ impl<'a> Loader<'a> {
         assert!(first_paddr.is_multiple_of(1 << aarch64::BLOCK_BITS_2MB));
         assert!(first_vaddr.is_multiple_of(1 << aarch64::BLOCK_BITS_2MB));
 
-        // Stage 1 or 2 depends on hypervisor config. TODO: Vary.
-        let hypervisor = true;
+        // Stage 1 or 2 depends on hypervisor config.
         #[rustfmt::skip]
-        let memattr_normal = if hypervisor {
+        let memattr_normal = if config.hypervisor {
             aarch64::MemAttr::Stage2 { mem_attr: aarch64::s2_mem_attr::NORMAL_INNER_WBC_OUTER_WBC }
         } else {
             aarch64::MemAttr::Stage1 { attr_index: aarch64::s1_mair_attr_index::MT_NORMAL }
         };
         #[rustfmt::skip]
-        let memattr_device = if hypervisor {
+        let memattr_device = if config.hypervisor {
             aarch64::MemAttr::Stage2 { mem_attr: aarch64::s2_mem_attr::DEVICE_nGnRnE }
         } else {
             aarch64::MemAttr::Stage1 { attr_index: aarch64::s1_mair_attr_index::MT_DEVICE_nGnRnE }

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -663,6 +663,12 @@ impl<'a> Loader<'a> {
         let (boot_lvl2_pt_addr, boot_lvl2_pt_size) = grab_symbol!(elf, "boot_lvl2_pt");
         let (boot_lvl2_pt_elf_addr, boot_lvl2_pt_elf_size) = grab_symbol!(elf, "boot_lvl2_pt_elf");
 
+        // We map the loader using 2MB pages, so make sure the base is actually aligned.
+        assert!(text_addr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
+        // We map the kernel using 2MB pages, so make sure the base is actually aligned.
+        assert!(first_paddr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
+        assert!(first_vaddr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
+
         let num_pt_levels = config.riscv_pt_levels.unwrap().levels();
 
         let mut boot_lvl1_pt: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
@@ -823,6 +829,10 @@ impl<'a> Loader<'a> {
 
         let (loader_start_addr, _) = grab_symbol!(elf, "_loader_start");
         let (loader_end_addr, _) = grab_symbol!(elf, "_loader_end");
+
+        // We map the kernel using 2MB pages, so make sure the base is actually aligned.
+        assert!(first_paddr.is_multiple_of(1 << aarch64::BLOCK_BITS_2MB));
+        assert!(first_vaddr.is_multiple_of(1 << aarch64::BLOCK_BITS_2MB));
 
         // Stage 1 or 2 depends on hypervisor config. TODO: Vary.
         let hypervisor = true;

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -6,7 +6,7 @@
 use crate::elf::{ElfFile, ElfSegmentData};
 use crate::sel4::{Arch, Config};
 use crate::uimage::uimage_serialise;
-use crate::util::{mask, mb, round_up, struct_to_bytes};
+use crate::util::{mb, round_up, struct_to_bytes};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::ops::Range;
@@ -14,67 +14,65 @@ use std::path::Path;
 
 const PAGE_TABLE_SIZE: usize = 4096;
 
-const AARCH64_1GB_BLOCK_BITS: u64 = 30;
-const AARCH64_2MB_BLOCK_BITS: u64 = 21;
+mod aarch64 {
+    use crate::util::mask;
 
-const AARCH64_LVL0_BITS: u64 = 9;
-const AARCH64_LVL1_BITS: u64 = 9;
-const AARCH64_LVL2_BITS: u64 = 9;
+    pub(crate) const BLOCK_BITS_1GB: u64 = 30;
+    pub(crate) const BLOCK_BITS_2MB: u64 = 21;
+    pub(crate) const LVL0_BITS: u64 = 9;
+    pub(crate) const LVL1_BITS: u64 = 9;
+    pub(crate) const LVL2_BITS: u64 = 9;
 
-struct Aarch64;
-impl Aarch64 {
     pub fn lvl0_index(addr: u64) -> usize {
-        let idx = (addr >> (AARCH64_2MB_BLOCK_BITS + AARCH64_LVL2_BITS + AARCH64_LVL1_BITS))
-            & mask(AARCH64_LVL0_BITS);
+        let idx = (addr >> (BLOCK_BITS_2MB + LVL2_BITS + LVL1_BITS)) & mask(LVL0_BITS);
         idx as usize
     }
 
     pub fn lvl1_index(addr: u64) -> usize {
-        let idx = (addr >> (AARCH64_2MB_BLOCK_BITS + AARCH64_LVL2_BITS)) & mask(AARCH64_LVL1_BITS);
+        let idx = (addr >> (BLOCK_BITS_2MB + LVL2_BITS)) & mask(LVL1_BITS);
         idx as usize
     }
 
     pub fn lvl2_index(addr: u64) -> usize {
-        let idx = (addr >> (AARCH64_2MB_BLOCK_BITS)) & mask(AARCH64_LVL2_BITS);
+        let idx = (addr >> (BLOCK_BITS_2MB)) & mask(LVL2_BITS);
         idx as usize
     }
 }
 
-struct Riscv64;
-impl Riscv64 {
-    const BLOCK_BITS_2MB: u64 = 21;
+mod riscv64 {
+    pub(crate) const BLOCK_BITS_2MB: u64 = 21;
 
-    const PAGE_TABLE_INDEX_BITS: u64 = 9;
-    const PAGE_SHIFT: u64 = 12;
+    pub(crate) const PAGE_TABLE_INDEX_BITS: u64 = 9;
+    pub(crate) const PAGE_SHIFT: u64 = 12;
     /// This sets the page table entry bits: D,A,X,W,R.
-    const PTE_TYPE_BITS: u64 = 0b11001110;
+    pub(crate) const PTE_TYPE_BITS: u64 = 0b11001110;
     // TODO: where does this come from?
-    const PTE_TYPE_TABLE: u64 = 0;
-    const PTE_TYPE_VALID: u64 = 1;
+    pub(crate) const PTE_TYPE_TABLE: u64 = 0;
+    pub(crate) const PTE_TYPE_VALID: u64 = 1;
 
-    const PTE_PPN0_SHIFT: u64 = 10;
+    pub(crate) const PTE_PPN0_SHIFT: u64 = 10;
 
     /// Due to RISC-V having various virtual memory setups, we have this generic function to
     /// figure out the page-table index given the total number of page table levels for the
     /// platform and which level we are currently looking at.
     pub fn pt_index(pt_levels: usize, addr: u64, level: usize) -> usize {
-        let pt_index_bits = Self::PAGE_TABLE_INDEX_BITS * (pt_levels - level) as u64;
-        let idx = (addr >> (pt_index_bits + Self::PAGE_SHIFT)) % 512;
+        let pt_index_bits = PAGE_TABLE_INDEX_BITS * (pt_levels - level) as u64;
+        let idx = (addr >> (pt_index_bits + PAGE_SHIFT)) % 512;
 
         idx as usize
     }
 
     /// Generate physical page number given an address
     pub fn pte_ppn(addr: u64) -> u64 {
-        (addr >> Self::PAGE_SHIFT) << Self::PTE_PPN0_SHIFT
+        (addr >> PAGE_SHIFT) << PTE_PPN0_SHIFT
     }
 
     pub fn pte_next(addr: u64) -> u64 {
-        Self::pte_ppn(addr) | Self::PTE_TYPE_TABLE | Self::PTE_TYPE_VALID
+        pte_ppn(addr) | PTE_TYPE_TABLE | PTE_TYPE_VALID
     }
 
     pub fn pte_leaf(addr: u64) -> u64 {
-        Self::pte_ppn(addr) | Self::PTE_TYPE_BITS | Self::PTE_TYPE_VALID
+        pte_ppn(addr) | PTE_TYPE_BITS | PTE_TYPE_VALID
     }
 }
 
@@ -416,8 +414,8 @@ impl<'a> Loader<'a> {
 
         let mut boot_lvl1_pt: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
-            let text_index_lvl1 = Riscv64::pt_index(num_pt_levels, text_addr, 1);
-            let pt_entry = Riscv64::pte_next(boot_lvl2_pt_elf_addr);
+            let text_index_lvl1 = riscv64::pt_index(num_pt_levels, text_addr, 1);
+            let pt_entry = riscv64::pte_next(boot_lvl2_pt_elf_addr);
             let start = 8 * text_index_lvl1;
             let end = start + 8;
             boot_lvl1_pt[start..end].copy_from_slice(&pt_entry.to_le_bytes());
@@ -425,33 +423,33 @@ impl<'a> Loader<'a> {
 
         let mut boot_lvl2_pt_elf: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
-            let text_index_lvl2 = Riscv64::pt_index(num_pt_levels, text_addr, 2);
+            let text_index_lvl2 = riscv64::pt_index(num_pt_levels, text_addr, 2);
             for (page, i) in (text_index_lvl2..512).enumerate() {
                 let start = 8 * i;
                 let end = start + 8;
-                let addr = text_addr + ((page as u64) << Riscv64::BLOCK_BITS_2MB);
-                let pt_entry = Riscv64::pte_leaf(addr);
+                let addr = text_addr + ((page as u64) << riscv64::BLOCK_BITS_2MB);
+                let pt_entry = riscv64::pte_leaf(addr);
                 boot_lvl2_pt_elf[start..end].copy_from_slice(&pt_entry.to_le_bytes());
             }
         }
 
         {
-            let index = Riscv64::pt_index(num_pt_levels, first_vaddr, 1);
+            let index = riscv64::pt_index(num_pt_levels, first_vaddr, 1);
             let start = 8 * index;
             let end = start + 8;
             boot_lvl1_pt[start..end]
-                .copy_from_slice(&Riscv64::pte_next(boot_lvl2_pt_addr).to_le_bytes());
+                .copy_from_slice(&riscv64::pte_next(boot_lvl2_pt_addr).to_le_bytes());
         }
 
         let mut boot_lvl2_pt: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
 
         {
-            let index = Riscv64::pt_index(num_pt_levels, first_vaddr, 2);
+            let index = riscv64::pt_index(num_pt_levels, first_vaddr, 2);
             for (page, i) in (index..512).enumerate() {
                 let start = 8 * i;
                 let end = start + 8;
-                let addr = first_paddr + ((page as u64) << Riscv64::BLOCK_BITS_2MB);
-                let pt_entry = Riscv64::pte_leaf(addr);
+                let addr = first_paddr + ((page as u64) << riscv64::BLOCK_BITS_2MB);
+                let pt_entry = riscv64::pte_leaf(addr);
                 boot_lvl2_pt[start..end].copy_from_slice(&pt_entry.to_le_bytes());
             }
         }
@@ -497,7 +495,7 @@ impl<'a> Loader<'a> {
             .find_symbol("_loader_end")
             .expect("Could not find 'loader_end' symbol");
 
-        if Aarch64::lvl1_index(start_addr) != Aarch64::lvl1_index(end_addr) {
+        if aarch64::lvl1_index(start_addr) != aarch64::lvl1_index(end_addr) {
             panic!("We only map 1GiB, but loader paddr range covers multiple GiB");
         }
 
@@ -513,9 +511,9 @@ impl<'a> Loader<'a> {
                 .expect("uart_addr not initialized");
             let uart_base = u64::from_le_bytes(data[0..8].try_into().unwrap());
 
-            let lvl1_idx = Aarch64::lvl1_index(uart_base);
+            let lvl1_idx = aarch64::lvl1_index(uart_base);
             #[allow(clippy::identity_op)] // keep the (0 << 2) for clarity
-            let pt_entry: u64 = ((lvl1_idx as u64) << AARCH64_1GB_BLOCK_BITS) |
+            let pt_entry: u64 = ((lvl1_idx as u64) << aarch64::BLOCK_BITS_1GB) |
                 (1 << 10) | // access flag
                 (0 << 2) | // strongly ordered memory
                 (1 << 0); // 1G block
@@ -528,15 +526,15 @@ impl<'a> Loader<'a> {
 
         // 1GB lvl1 Table entry
         let pt_entry = (boot_lvl2_lower_addr | 3).to_le_bytes();
-        let lvl1_idx = Aarch64::lvl1_index(start_addr);
+        let lvl1_idx = aarch64::lvl1_index(start_addr);
         let start = 8 * lvl1_idx;
         let end = 8 * (lvl1_idx + 1);
         boot_lvl1_lower[start..end].copy_from_slice(&pt_entry);
 
         // map the loader 1:1 access into 2MB lvl2 Block entries for a 4KB granule
-        let lvl2_idx = Aarch64::lvl2_index(start_addr);
-        for i in lvl2_idx..=Aarch64::lvl2_index(end_addr) {
-            let entry_idx = (i - Aarch64::lvl2_index(start_addr)) << AARCH64_2MB_BLOCK_BITS;
+        let lvl2_idx = aarch64::lvl2_index(start_addr);
+        for i in lvl2_idx..=aarch64::lvl2_index(end_addr) {
+            let entry_idx = (i - aarch64::lvl2_index(start_addr)) << aarch64::BLOCK_BITS_2MB;
             let pt_entry: u64 = (entry_idx as u64 + start_addr) |
                 (1 << 10) | // Access flag
                 (3 << 8) | // Sharable
@@ -550,12 +548,12 @@ impl<'a> Loader<'a> {
         // TODO: this is a complete hack specific to BCM2711/Raspberry Pi 4B and
         // will be removed with patches that re-do this loader mapping code.
         if elf.find_symbol("cpus_release_addr").is_ok() {
-            let lvl2_idx = Aarch64::lvl2_index(0);
+            let lvl2_idx = aarch64::lvl2_index(0);
             // Make sure we don't override the loader mappings done above.
-            assert!(Aarch64::lvl2_index(start_addr) != lvl2_idx);
-            assert!(Aarch64::lvl1_index(start_addr) == Aarch64::lvl1_index(0));
+            assert!(aarch64::lvl2_index(start_addr) != lvl2_idx);
+            assert!(aarch64::lvl1_index(start_addr) == aarch64::lvl1_index(0));
             #[allow(clippy::identity_op)] // keep the (0 << 2) for clarity
-            let pt_entry: u64 = ((lvl2_idx as u64) << AARCH64_2MB_BLOCK_BITS) |
+            let pt_entry: u64 = ((lvl2_idx as u64) << aarch64::BLOCK_BITS_2MB) |
                 (1 << 10) | // access flag
                 (0 << 2) | // strongly ordered memory
                 (1 << 0); // 2M block
@@ -567,22 +565,22 @@ impl<'a> Loader<'a> {
         let boot_lvl0_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let pt_entry = (boot_lvl1_upper_addr | 3).to_le_bytes();
-            let idx = Aarch64::lvl0_index(first_vaddr);
+            let idx = aarch64::lvl0_index(first_vaddr);
             boot_lvl0_lower[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry);
         }
 
         let mut boot_lvl1_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let pt_entry = (boot_lvl2_upper_addr | 3).to_le_bytes();
-            let idx = Aarch64::lvl1_index(first_vaddr);
+            let idx = aarch64::lvl1_index(first_vaddr);
             boot_lvl1_upper[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry);
         }
 
         let mut boot_lvl2_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
 
-        let lvl2_idx = Aarch64::lvl2_index(first_vaddr);
+        let lvl2_idx = aarch64::lvl2_index(first_vaddr);
         for i in lvl2_idx..512 {
-            let entry_idx = (i - Aarch64::lvl2_index(first_vaddr)) << AARCH64_2MB_BLOCK_BITS;
+            let entry_idx = (i - aarch64::lvl2_index(first_vaddr)) << aarch64::BLOCK_BITS_2MB;
             let pt_entry: u64 = (entry_idx as u64 + first_paddr) |
                 (1 << 10) | // Access flag
                 (3 << 8) | // Make sure the shareability is the same as the kernel's


### PR DESCRIPTION
This is a series of cleanups, except for one commit:

We were previously setting the MemAttr to the Stage 1 AttrIndex values from MAIR_EL1, but since we boot in hyp/stage 2 we were using the reserved 0b100 value (which is constrained unpredictable to behave as one of the other values).