### PR TITLE
tool: fix kernel mappings for RISC-V loader

### DIFF
--- a/loader/src/riscv/mmu.c
+++ b/loader/src/riscv/mmu.c
@@ -14,7 +14,7 @@
 uint64_t boot_lvl1_pt[1 << 9] ALIGN(1 << 12);
 uint64_t boot_lvl2_pt[1 << 9] ALIGN(1 << 12);
 /* Paging structures for identity mapping */
-uint64_t boot_lvl2_pt_elf[1 << 9] ALIGN(1 << 12);
+uint64_t boot_lvl2_pt_loader[1 << 9] ALIGN(1 << 12);
 
 
 /*

--- a/loader/src/riscv/mmu.c
+++ b/loader/src/riscv/mmu.c
@@ -13,6 +13,7 @@
 /* Paging structures for kernel mapping */
 uint64_t boot_lvl1_pt[1 << 9] ALIGN(1 << 12);
 uint64_t boot_lvl2_pt[1 << 9] ALIGN(1 << 12);
+uint64_t boot_lvl3_pt[1 << 9] ALIGN(1 << 12);
 /* Paging structures for identity mapping */
 uint64_t boot_lvl2_pt_loader[1 << 9] ALIGN(1 << 12);
 

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -664,7 +664,8 @@ impl<'a> Loader<'a> {
         let (boot_lvl1_pt_addr, boot_lvl1_pt_size) = grab_symbol!(elf, "boot_lvl1_pt");
         let (boot_lvl2_pt_addr, boot_lvl2_pt_size) = grab_symbol!(elf, "boot_lvl2_pt");
         let (boot_lvl3_pt_addr, boot_lvl3_pt_size) = grab_symbol!(elf, "boot_lvl3_pt");
-        let (boot_lvl2_pt_loader_addr, boot_lvl2_pt_loader_size) = grab_symbol!(elf, "boot_lvl2_pt_loader");
+        let (boot_lvl2_pt_loader_addr, boot_lvl2_pt_loader_size) =
+            grab_symbol!(elf, "boot_lvl2_pt_loader");
 
         // We map the loader using 2MB pages, so make sure the base is actually aligned.
         assert!(text_addr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -302,6 +302,7 @@ pub mod aarch64 {
 
 mod riscv64 {
     pub(crate) const BLOCK_BITS_2MB: u64 = 21;
+    pub(crate) const PAGE_BITS_4K: u64 = 12;
 
     pub(crate) const PAGE_TABLE_INDEX_BITS: u64 = 9;
     pub(crate) const PAGE_SHIFT: u64 = 12;
@@ -662,13 +663,11 @@ impl<'a> Loader<'a> {
         let (text_addr, _) = grab_symbol!(elf, "_text");
         let (boot_lvl1_pt_addr, boot_lvl1_pt_size) = grab_symbol!(elf, "boot_lvl1_pt");
         let (boot_lvl2_pt_addr, boot_lvl2_pt_size) = grab_symbol!(elf, "boot_lvl2_pt");
+        let (boot_lvl3_pt_addr, boot_lvl3_pt_size) = grab_symbol!(elf, "boot_lvl3_pt");
         let (boot_lvl2_pt_loader_addr, boot_lvl2_pt_loader_size) = grab_symbol!(elf, "boot_lvl2_pt_loader");
 
         // We map the loader using 2MB pages, so make sure the base is actually aligned.
         assert!(text_addr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
-        // We map the kernel using 2MB pages, so make sure the base is actually aligned.
-        assert!(first_paddr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
-        assert!(first_vaddr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
 
         let num_pt_levels = config.riscv_pt_levels.unwrap().levels();
 
@@ -701,14 +700,33 @@ impl<'a> Loader<'a> {
                 .copy_from_slice(&riscv64::pte_next(boot_lvl2_pt_addr).to_le_bytes());
         }
 
+        let mut boot_lvl3_pt: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         let mut boot_lvl2_pt: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
-
         {
-            let index = riscv64::pt_index(num_pt_levels, first_vaddr, 2);
-            for (page, i) in (index..512).enumerate() {
+            let mut index_lvl2 = riscv64::pt_index(num_pt_levels, first_vaddr, 2);
+            if !first_vaddr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB) {
+                let index_lvl3 = riscv64::pt_index(num_pt_levels, first_vaddr, 3);
+                for (page, i) in (index_lvl3..512).enumerate() {
+                    let start = 8 * i;
+                    let end = start + 8;
+                    let addr = first_paddr + ((page as u64) << riscv64::PAGE_BITS_4K);
+                    assert!(addr.is_multiple_of(1 << riscv64::PAGE_BITS_4K));
+                    let pt_entry = riscv64::pte_leaf(addr);
+                    boot_lvl3_pt[start..end].copy_from_slice(&pt_entry.to_le_bytes());
+                }
+                let start = 8 * index_lvl2;
+                let end = start + 8;
+                let lvl3_pt_entry = riscv64::pte_next(boot_lvl3_pt_addr);
+                assert!(boot_lvl3_pt_addr.is_multiple_of(1 << riscv64::PAGE_BITS_4K));
+                boot_lvl2_pt[start..end].copy_from_slice(&lvl3_pt_entry.to_le_bytes());
+                index_lvl2 += 1;
+            }
+            let first_paddr_aligned = round_up(first_paddr, 1 << riscv64::BLOCK_BITS_2MB);
+            for (page, i) in (index_lvl2..512).enumerate() {
                 let start = 8 * i;
                 let end = start + 8;
-                let addr = first_paddr + ((page as u64) << riscv64::BLOCK_BITS_2MB);
+                let addr = first_paddr_aligned + ((page as u64) << riscv64::BLOCK_BITS_2MB);
+                assert!(addr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
                 let pt_entry = riscv64::pte_leaf(addr);
                 boot_lvl2_pt[start..end].copy_from_slice(&pt_entry.to_le_bytes());
             }
@@ -717,6 +735,7 @@ impl<'a> Loader<'a> {
         vec![
             (boot_lvl1_pt_addr, boot_lvl1_pt_size, boot_lvl1_pt),
             (boot_lvl2_pt_addr, boot_lvl2_pt_size, boot_lvl2_pt),
+            (boot_lvl3_pt_addr, boot_lvl3_pt_size, boot_lvl3_pt),
             (
                 boot_lvl2_pt_loader_addr,
                 boot_lvl2_pt_loader_size,

--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -662,7 +662,7 @@ impl<'a> Loader<'a> {
         let (text_addr, _) = grab_symbol!(elf, "_text");
         let (boot_lvl1_pt_addr, boot_lvl1_pt_size) = grab_symbol!(elf, "boot_lvl1_pt");
         let (boot_lvl2_pt_addr, boot_lvl2_pt_size) = grab_symbol!(elf, "boot_lvl2_pt");
-        let (boot_lvl2_pt_elf_addr, boot_lvl2_pt_elf_size) = grab_symbol!(elf, "boot_lvl2_pt_elf");
+        let (boot_lvl2_pt_loader_addr, boot_lvl2_pt_loader_size) = grab_symbol!(elf, "boot_lvl2_pt_loader");
 
         // We map the loader using 2MB pages, so make sure the base is actually aligned.
         assert!(text_addr.is_multiple_of(1 << riscv64::BLOCK_BITS_2MB));
@@ -675,13 +675,13 @@ impl<'a> Loader<'a> {
         let mut boot_lvl1_pt: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let text_index_lvl1 = riscv64::pt_index(num_pt_levels, text_addr, 1);
-            let pt_entry = riscv64::pte_next(boot_lvl2_pt_elf_addr);
+            let pt_entry = riscv64::pte_next(boot_lvl2_pt_loader_addr);
             let start = 8 * text_index_lvl1;
             let end = start + 8;
             boot_lvl1_pt[start..end].copy_from_slice(&pt_entry.to_le_bytes());
         }
 
-        let mut boot_lvl2_pt_elf: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
+        let mut boot_lvl2_pt_loader: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let text_index_lvl2 = riscv64::pt_index(num_pt_levels, text_addr, 2);
             for (page, i) in (text_index_lvl2..512).enumerate() {
@@ -689,7 +689,7 @@ impl<'a> Loader<'a> {
                 let end = start + 8;
                 let addr = text_addr + ((page as u64) << riscv64::BLOCK_BITS_2MB);
                 let pt_entry = riscv64::pte_leaf(addr);
-                boot_lvl2_pt_elf[start..end].copy_from_slice(&pt_entry.to_le_bytes());
+                boot_lvl2_pt_loader[start..end].copy_from_slice(&pt_entry.to_le_bytes());
             }
         }
 
@@ -718,9 +718,9 @@ impl<'a> Loader<'a> {
             (boot_lvl1_pt_addr, boot_lvl1_pt_size, boot_lvl1_pt),
             (boot_lvl2_pt_addr, boot_lvl2_pt_size, boot_lvl2_pt),
             (
-                boot_lvl2_pt_elf_addr,
-                boot_lvl2_pt_elf_size,
-                boot_lvl2_pt_elf,
+                boot_lvl2_pt_loader_addr,
+                boot_lvl2_pt_loader_size,
+                boot_lvl2_pt_loader,
             ),
         ]
     }


### PR DESCRIPTION
Done on top of https://github.com/seL4/microkit/pull/482.

See commit message for details.

Closes https://github.com/seL4/microkit/issues/481.