### PR TITLE
tool: fix regression from bde5eb

### DIFF
--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -852,10 +852,6 @@ impl<'a> Loader<'a> {
         let (loader_start_addr, _) = grab_symbol!(elf, "_loader_start");
         let (loader_end_addr, _) = grab_symbol!(elf, "_loader_end");
 
-        // We map the kernel using 2MB pages, so make sure the base is actually aligned.
-        assert!(first_paddr.is_multiple_of(1 << aarch64::BLOCK_BITS_2MB));
-        assert!(first_vaddr.is_multiple_of(1 << aarch64::BLOCK_BITS_2MB));
-
         // Stage 1 or 2 depends on hypervisor config.
         #[rustfmt::skip]
         let memattr_normal = if config.hypervisor {


### PR DESCRIPTION
I wrongly assumed that the kernel started at a 2MB alignment and so for certain platforms (particularly, the Raspberry Pi 4B), this assert goes off.

We do not need this assert since it is expected the kernel is not always 2MB aligned. The loader code still always uses 2MB pages for mapping the kernel, however it will round down to the nearest 2MB alignment which is why this hasn't been an issue previously. This logic follows what the kernel does for its own mappings as well.