### PR TITLE
tool: Separate argument parsing

### DIFF
--- a/tool/microkit/src/argparse.rs
+++ b/tool/microkit/src/argparse.rs
@@ -1,0 +1,239 @@
+//
+// Copyright 2025, UNSW
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+use std::fmt;
+use std::iter::Peekable;
+use std::path::PathBuf;
+
+pub fn print_usage() {
+    println!("usage: microkit [-h] [OPTIONS] --board BOARD --config CONFIG [--search-path SEARCH_PATH ...] system")
+}
+
+pub fn print_help(available_boards: &[String]) {
+    print_usage();
+    println!("\npositional arguments:");
+    println!("  system");
+    println!("\noptions:");
+    println!("  -h, --help, show this help message and exit");
+    println!("  -o, --output OUTPUT");
+    println!("  -r, --report REPORT");
+    println!("  --image-type {{binary,elf,uimage}}");
+    println!("  --override-kernel KERNEL (for debugging purposes)");
+    println!("  --board {}", available_boards.join("\n          "));
+    println!("  --config CONFIG");
+    println!("  --capdl-json CAPDL_SPEC (JSON format)");
+    println!("  --search-path [SEARCH_PATH ...]");
+}
+
+#[derive(Debug, Clone)]
+pub enum RequestedImageType {
+    Binary,
+    Elf,
+    Uimage,
+    Unspecified,
+}
+
+impl RequestedImageType {
+    fn parse(arg: &str) -> Option<Self> {
+        match arg {
+            "binary" => Some(RequestedImageType::Binary),
+            "elf" => Some(RequestedImageType::Elf),
+            "uimage" => Some(RequestedImageType::Uimage),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RequestedImageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RequestedImageType::Binary => write!(f, "binary"),
+            RequestedImageType::Elf => write!(f, "elf"),
+            RequestedImageType::Uimage => write!(f, "uimage"),
+            RequestedImageType::Unspecified => write!(f, "unspecified"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    pub sdf_path: PathBuf,
+    pub board: String,
+    pub config: String,
+    pub report_path: PathBuf,
+    pub capdl_json_path: Option<PathBuf>,
+    pub output_path: PathBuf,
+    pub search_paths: Vec<PathBuf>,
+    pub requested_image_type: RequestedImageType,
+    pub override_kernel: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub enum ArgsError {
+    InvalidImageTypeParameter { parameter: String },
+    InvalidBoardParameter { parameter: String },
+    MissingParameter { parent_argument: &'static str },
+    MissingRequiredArguments { args: Vec<&'static str> },
+    UnrecognizedArgument { arg: String },
+    HelpWanted,
+}
+
+impl fmt::Display for ArgsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidImageTypeParameter { parameter } => {
+                write!(f, "argument --image-type: unknown parameter '{parameter}'")
+            }
+            Self::InvalidBoardParameter { parameter } => {
+                write!(f, "argument --board: unknown parameter '{parameter}'")
+            }
+            Self::MissingParameter { parent_argument } => {
+                write!(f, "argument {parent_argument}: expected one parameter")
+            }
+            Self::MissingRequiredArguments { args } => {
+                write!(
+                    f,
+                    "the following arguments are required: {}",
+                    args.join(", ")
+                )
+            }
+            Self::UnrecognizedArgument { arg } => {
+                write!(f, "unrecognized argument '{arg}'")
+            }
+            Self::HelpWanted => {
+                write!(f, "printing help text")
+            }
+        }
+    }
+}
+
+fn consume_parameter<I>(args: &mut I, argname: &'static str) -> Result<String, ArgsError>
+where
+    I: Iterator<Item = String>,
+{
+    args.next().ok_or(ArgsError::MissingParameter {
+        parent_argument: argname,
+    })
+}
+
+fn consume_parameters<I>(args: &mut Peekable<I>) -> Vec<String>
+where
+    I: Iterator<Item = String>,
+{
+    let mut values = Vec::new();
+    while let Some(next) = args.peek() {
+        if next.starts_with("-") {
+            break;
+        }
+        if let Some(next) = args.next() {
+            values.push(next)
+        };
+    }
+    values
+}
+
+impl Args {
+    pub fn parse(args: &[String], available_boards: &[String]) -> Result<Self, ArgsError> {
+        let mut args = args.iter().skip(1).cloned().peekable();
+
+        let mut output_path = PathBuf::from("loader.img");
+        let mut report_path = PathBuf::from("report.txt");
+        let mut capdl_json_path = None;
+        let mut search_paths = Vec::new();
+
+        let mut sdf_path = None;
+        let mut board = None;
+        let mut config = None;
+        let mut requested_image_type = RequestedImageType::Unspecified;
+        let mut override_kernel = None;
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "-h" | "--help" => {
+                    return Err(ArgsError::HelpWanted);
+                }
+                "-o" | "--output" => {
+                    output_path = consume_parameter(&mut args, "--output")?.into();
+                }
+                "-r" | "--report" => {
+                    report_path = consume_parameter(&mut args, "--report")?.into();
+                }
+                "--board" => {
+                    let board_param = consume_parameter(&mut args, "--board")?;
+                    if !available_boards.contains(&board_param) {
+                        return Err(ArgsError::InvalidBoardParameter {
+                            parameter: board_param,
+                        });
+                    }
+                    board = Some(board_param);
+                }
+                "--config" => {
+                    config = Some(consume_parameter(&mut args, "--config")?);
+                }
+                "--capdl-json" => {
+                    capdl_json_path = Some(consume_parameter(&mut args, "--capdl-json")?.into());
+                }
+                "--search-path" => {
+                    let params = consume_parameters(&mut args);
+                    search_paths.extend(params.into_iter().map(PathBuf::from));
+                }
+                "--image-type" => {
+                    let value = consume_parameter(&mut args, "--image-type")?;
+                    match RequestedImageType::parse(value.as_str()) {
+                        Some(image_type) => {
+                            requested_image_type = image_type;
+                        }
+                        None => {
+                            return Err(ArgsError::InvalidImageTypeParameter { parameter: value });
+                        }
+                    }
+                }
+                "--override-kernel" => {
+                    override_kernel =
+                        Some(consume_parameter(&mut args, "--override-kernel")?.into());
+                }
+                value => {
+                    if sdf_path.is_none() {
+                        sdf_path = Some(value.into());
+                    } else {
+                        return Err(ArgsError::UnrecognizedArgument {
+                            arg: value.to_owned(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut missing_args = Vec::new();
+        if board.is_none() {
+            missing_args.push("--board");
+        }
+        if config.is_none() {
+            missing_args.push("--config");
+        }
+        if sdf_path.is_none() {
+            missing_args.push("system");
+        }
+        if !missing_args.is_empty() {
+            return Err(ArgsError::MissingRequiredArguments { args: missing_args });
+        }
+        let board = board.unwrap();
+        let config = config.unwrap();
+        let sdf_path = sdf_path.unwrap();
+
+        Ok(Self {
+            sdf_path,
+            board,
+            config,
+            report_path,
+            capdl_json_path,
+            output_path,
+            search_paths,
+            requested_image_type,
+            override_kernel,
+        })
+    }
+}

--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -11,6 +11,7 @@ use crate::{
     util::struct_to_bytes,
 };
 
+pub mod argparse;
 pub mod capdl;
 pub mod crc32;
 pub mod elf;

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -7,6 +7,8 @@
 // we want our asserts, even if the compiler figures out they hold true already during compile-time
 #![allow(clippy::assertions_on_constants)]
 
+use microkit_tool::argparse;
+use microkit_tool::argparse::{Args, ArgsError, RequestedImageType};
 use microkit_tool::capdl::allocation::{
     simulate_capdl_object_alloc_algorithm, CapDLAllocEmulationErrorLevel,
 };
@@ -29,7 +31,7 @@ use microkit_tool::util::{
 use microkit_tool::{DisjointMemoryRegion, MemoryRegion};
 use std::collections::HashMap;
 use std::fs::{self, metadata};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 const MAX_BUILD_ITERATION: usize = 3;
 
@@ -40,26 +42,6 @@ const KERNEL_COPY_FILENAME: &str = "sel4.elf";
 // The `-kernel` argument of 'qemu-system-x86_64' doesn't accept a 64-bit image, so we
 // also copy the 32-bit version that was prepared by build_sdk.py for convenience.
 const KERNEL32_COPY_FILENAME: &str = "sel4_32.elf";
-
-fn print_usage() {
-    println!("usage: microkit [-h] [OPTIONS] --board BOARD --config CONFIG [--search-path SEARCH_PATH ...] system")
-}
-
-fn print_help(available_boards: &[String]) {
-    print_usage();
-    println!("\npositional arguments:");
-    println!("  system");
-    println!("\noptions:");
-    println!("  -h, --help, show this help message and exit");
-    println!("  -o, --output OUTPUT");
-    println!("  -r, --report REPORT");
-    println!("  --image-type {{binary,elf}}");
-    println!("  --override-kernel KERNEL (for debugging purposes)");
-    println!("  --board {}", available_boards.join("\n          "));
-    println!("  --config CONFIG");
-    println!("  --capdl-json CAPDL_SPEC (JSON format)");
-    println!("  --search-path [SEARCH_PATH ...]");
-}
 
 enum ImageOutputType {
     Binary,
@@ -79,194 +61,23 @@ impl ImageOutputType {
         }
     }
 
-    fn parse(str: &str, arch: Arch) -> Result<Self, String> {
-        match str {
-            "binary" => match arch {
-                Arch::Aarch64 | Arch::Riscv64 => Ok(ImageOutputType::Binary),
-                Arch::X86_64 => Err(format!(
-                    "building the output image as binary is unsupported for target architecture '{arch}'"
-                )),
+    /// Resolve the optional user-specified image type with what is the default for the
+    /// platform.
+    /// Not all image types are supported for all platforms, so we check here.
+    fn resolve(requested: &RequestedImageType, arch: &Arch, board_name: &str) -> Option<Self> {
+        match requested {
+            RequestedImageType::Binary => match arch {
+                Arch::Aarch64 | Arch::Riscv64 => Some(Self::Binary),
+                Arch::X86_64 => None,
             },
-            "elf" => Ok(ImageOutputType::Elf),
-            "uimage" => match arch {
-                Arch::Riscv64 => Ok(ImageOutputType::Uimage),
-                Arch::X86_64 | Arch::Aarch64 => Err(format!(
-                    "building the output image as uImage is unsupported for target architecture '{arch}'"
-                )),
+            RequestedImageType::Elf => Some(Self::Elf),
+            RequestedImageType::Uimage => match arch {
+                Arch::Riscv64 => Some(Self::Uimage),
+                Arch::X86_64 | Arch::Aarch64 => None,
             },
-            _ => Err(format!("unknown value '{str}'")),
-        }
-    }
-}
-
-struct Args<'a> {
-    system: &'a str,
-    board: &'a str,
-    config: &'a str,
-    report: &'a str,
-    capdl_json: Option<&'a str>,
-    output: &'a str,
-    search_paths: Vec<&'a String>,
-    output_image_type: Option<&'a str>,
-    override_kernel: Option<&'a str>,
-}
-
-impl<'a> Args<'a> {
-    pub fn parse(args: &'a [String], available_boards: &[String]) -> Args<'a> {
-        // Default arguments
-        let mut output = "loader.img";
-        let mut report = "report.txt";
-        let mut capdl_json = None;
-        let mut search_paths = Vec::new();
-        // Arguments expected to be provided by the user
-        let mut system = None;
-        let mut board = None;
-        let mut config = None;
-        let mut output_image_type = None;
-        let mut override_kernel = None;
-
-        if args.len() <= 1 {
-            print_usage();
-            std::process::exit(1);
-        }
-
-        let mut i = 1;
-        let mut unknown = vec![];
-        let mut in_search_path = false;
-        while i < args.len() {
-            match args[i].as_str() {
-                "-h" | "--help" => {
-                    print_help(available_boards);
-                    std::process::exit(0);
-                }
-                "-o" | "--output" => {
-                    in_search_path = false;
-                    if i < args.len() - 1 {
-                        output = &args[i + 1];
-                        i += 1;
-                    } else {
-                        eprintln!("microkit: error: argument -o/--output: expected one argument");
-                        std::process::exit(1);
-                    }
-                }
-                "-r" | "--report" => {
-                    in_search_path = false;
-                    if i < args.len() - 1 {
-                        report = &args[i + 1];
-                        i += 1;
-                    } else {
-                        eprintln!("microkit: error: argument -r/--report: expected one argument");
-                        std::process::exit(1);
-                    }
-                }
-                "--board" => {
-                    in_search_path = false;
-                    if i < args.len() - 1 {
-                        board = Some(&args[i + 1]);
-                        i += 1;
-                    } else {
-                        eprintln!("microkit: error: argument --board: expected one argument");
-                        std::process::exit(1);
-                    }
-                }
-                "--config" => {
-                    in_search_path = false;
-                    if i < args.len() - 1 {
-                        config = Some(&args[i + 1]);
-                        i += 1;
-                    } else {
-                        eprintln!("microkit: error: argument --config: expected one argument");
-                        std::process::exit(1);
-                    }
-                }
-                "--capdl-json" => {
-                    in_search_path = false;
-                    if i < args.len() - 1 {
-                        capdl_json = Some(args[i + 1].as_str());
-                        i += 1;
-                    } else {
-                        eprintln!("microkit: error: argument --capdl-json: expected one argument");
-                        std::process::exit(1);
-                    }
-                }
-                "--search-path" => {
-                    in_search_path = true;
-                }
-                "--image-type" => {
-                    if i < args.len() - 1 {
-                        output_image_type = Some(args[i + 1].as_str());
-                        i += 1;
-                    } else {
-                        eprintln!("microkit: error: argument --image-type: expected one argument");
-                        std::process::exit(1);
-                    }
-                }
-                "--override-kernel" => {
-                    if i < args.len() - 1 {
-                        override_kernel = Some(args[i + 1].as_str());
-                        i += 1;
-                    } else {
-                        eprintln!(
-                            "microkit: error: argument --override-kernel: expected one argument"
-                        );
-                        std::process::exit(1);
-                    }
-                }
-                _ => {
-                    if in_search_path {
-                        search_paths.push(&args[i]);
-                    } else if system.is_none() {
-                        system = Some(&args[i]);
-                    } else {
-                        // This call to clone is okay since having unknown
-                        // arguments is rare.
-                        unknown.push(args[i].clone());
-                    }
-                }
+            RequestedImageType::Unspecified => {
+                Some(Self::default_from_arch_and_board(arch, board_name))
             }
-
-            i += 1;
-        }
-
-        if !unknown.is_empty() {
-            print_usage();
-            eprintln!(
-                "microkit: error: unrecognised arguments: {}",
-                unknown.join(" ")
-            );
-            std::process::exit(1);
-        }
-
-        let mut missing_args = Vec::new();
-        if board.is_none() {
-            missing_args.push("--board");
-        }
-        if config.is_none() {
-            missing_args.push("--config");
-        }
-        if system.is_none() {
-            missing_args.push("system");
-        }
-
-        if !missing_args.is_empty() {
-            print_usage();
-            eprintln!(
-                "microkit: error: the following arguments are required: {}",
-                missing_args.join(", ")
-            );
-            std::process::exit(1);
-        }
-
-        Args {
-            system: system.unwrap(),
-            board: board.unwrap(),
-            config: config.unwrap(),
-            report,
-            capdl_json,
-            output,
-            search_paths,
-            output_image_type,
-            override_kernel,
         }
     }
 }
@@ -315,9 +126,26 @@ fn main() -> Result<(), String> {
     available_boards.sort();
 
     let env_args: Vec<_> = std::env::args().collect();
-    let args = Args::parse(&env_args, &available_boards);
+    let args = match Args::parse(&env_args, &available_boards) {
+        Ok(result) => result,
+        Err(ArgsError::HelpWanted) => {
+            argparse::print_help(&available_boards);
+            std::process::exit(0);
+        }
+        Err(err) => {
+            match err {
+                ArgsError::UnrecognizedArgument { arg: _ }
+                | ArgsError::MissingRequiredArguments { args: _ } => {
+                    argparse::print_usage();
+                }
+                _ => {}
+            };
+            eprintln!("microkit: error: {err}");
+            std::process::exit(1);
+        }
+    };
 
-    let board_path = boards_path.join(args.board);
+    let board_path = boards_path.join(&args.board);
     if !board_path.exists() {
         eprintln!(
             "Error: board path '{}' does not exist.",
@@ -350,12 +178,12 @@ fn main() -> Result<(), String> {
 
     let elf_path = sdk_dir
         .join("board")
-        .join(args.board)
-        .join(args.config)
+        .join(&args.board)
+        .join(&args.config)
         .join("elf");
     let loader_elf_path = elf_path.join("loader.elf");
     let kernel_elf_path = match args.override_kernel {
-        Some(path) => Path::new(path),
+        Some(ref path) => path,
         None => &elf_path.join("sel4.elf"),
     };
     let monitor_elf_path = elf_path.join("monitor.elf");
@@ -363,14 +191,14 @@ fn main() -> Result<(), String> {
 
     let kernel_config_path = sdk_dir
         .join("board")
-        .join(args.board)
-        .join(args.config)
+        .join(&args.board)
+        .join(&args.config)
         .join("include/kernel/gen_config.json");
 
     let invocations_all_path = sdk_dir
         .join("board")
-        .join(args.board)
-        .join(args.config)
+        .join(&args.board)
+        .join(&args.config)
         .join("invocations_all.json");
 
     if !elf_path.exists() {
@@ -416,7 +244,7 @@ fn main() -> Result<(), String> {
         std::process::exit(1);
     }
 
-    let system_path = Path::new(args.system);
+    let system_path = &args.sdf_path;
     if !system_path.exists() {
         eprintln!(
             "Error: system description file '{}' does not exist",
@@ -425,7 +253,7 @@ fn main() -> Result<(), String> {
         std::process::exit(1);
     }
 
-    let xml: String = fs::read_to_string(args.system).unwrap();
+    let xml: String = fs::read_to_string(system_path).unwrap();
 
     let kernel_config_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(kernel_config_path).unwrap()).unwrap();
@@ -440,16 +268,19 @@ fn main() -> Result<(), String> {
         _ => panic!("Unsupported kernel config architecture"),
     };
 
-    let image_output_type = if let Some(image_type) = args.output_image_type {
-        match ImageOutputType::parse(image_type, arch) {
-            Ok(output_image_type) => output_image_type,
-            Err(reason) => {
-                eprintln!("microkit: error: argument --image-type: {reason}");
-                std::process::exit(1);
-            }
+    let image_output_type = match ImageOutputType::resolve(
+        &args.requested_image_type,
+        &arch,
+        args.board.as_str(),
+    ) {
+        Some(image) => image,
+        None => {
+            eprintln!(
+                    "microkit: error: building the output image as '{0}' is unsupported for target architecture '{arch}'",
+                    args.requested_image_type
+                );
+            std::process::exit(1);
         }
-    } else {
-        ImageOutputType::default_from_arch_and_board(&arch, args.board)
     };
 
     let (device_regions, normal_regions) = match arch {
@@ -457,8 +288,8 @@ fn main() -> Result<(), String> {
         _ => {
             let kernel_platform_config_path = sdk_dir
                 .join("board")
-                .join(args.board)
-                .join(args.config)
+                .join(&args.board)
+                .join(&args.config)
                 .join("platform_gen.json");
 
             if !kernel_platform_config_path.exists() {
@@ -484,7 +315,7 @@ fn main() -> Result<(), String> {
         let object_sizes_path = sdk_dir
             .join("board")
             .join(args.board)
-            .join(args.config)
+            .join(&args.config)
             .join("object_sizes.json");
 
         if !object_sizes_path.exists() {
@@ -581,12 +412,12 @@ fn main() -> Result<(), String> {
         "Microkit tool has various assumptions about the word size being 64-bits."
     );
 
-    let mut search_paths = vec![std::env::current_dir().unwrap()];
-    for path in args.search_paths {
-        search_paths.push(PathBuf::from(path));
-    }
-
-    let mut system = match parse(args.system, &xml, &kernel_config, &search_paths) {
+    let mut system = match parse(
+        system_path.as_path(),
+        &xml,
+        &kernel_config,
+        &args.search_paths,
+    ) {
         Ok(system) => system,
         Err(err) => {
             eprintln!("{err}");
@@ -649,13 +480,13 @@ fn main() -> Result<(), String> {
     let mut system_elfs = Vec::with_capacity(system.protection_domains.len());
     // Get the elf files for each pd:
     for pd in &system.protection_domains {
-        match get_full_path(&pd.program_image, &search_paths) {
+        match get_full_path(&pd.program_image, &args.search_paths) {
             Some(path) => {
                 let path_for_symbols = pd
                     .program_image_for_symbols
                     .as_ref()
                     .map(|path_suffix| {
-                        get_full_path(path_suffix, &search_paths).ok_or_else(|| {
+                        get_full_path(path_suffix, &args.search_paths).ok_or_else(|| {
                             format!(
                                 "unable to find program image for symbols: '{}'",
                                 path_suffix.display()
@@ -707,7 +538,7 @@ fn main() -> Result<(), String> {
         let mut spec_container = build_capdl_spec(&kernel_config, &mut system_elfs, &system)?;
         pack_spec_into_initial_task(
             &kernel_config,
-            args.config,
+            args.config.as_str(),
             &spec_container,
             &system_elfs,
             &mut capdl_initialiser,
@@ -932,7 +763,7 @@ fn main() -> Result<(), String> {
                 human_size_strict(initialiser_vaddr_range.end - initialiser_vaddr_range.start),
             );
 
-            let image_out_path = Path::new(args.output);
+            let image_out_path = args.output_path.as_path();
 
             match kernel_config.arch {
                 Arch::X86_64 => match capdl_initialiser.elf.reserialise(image_out_path) {
@@ -991,12 +822,12 @@ fn main() -> Result<(), String> {
                 }
             };
 
-            if let Some(capdl_json) = args.capdl_json {
+            if let Some(capdl_json) = args.capdl_json_path {
                 let serialised = serde_json::to_string_pretty(&spec_container.spec).unwrap();
                 fs::write(capdl_json, &serialised).unwrap();
             };
 
-            write_report(&spec_container, &kernel_config, args.report);
+            write_report(&spec_container, &kernel_config, &args.report_path);
             system_built = true;
             break;
         } else {

--- a/tool/microkit/src/report.rs
+++ b/tool/microkit/src/report.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
+use std::path::Path;
 use std::{fs::File, io::Write};
 
 use sel4_capdl_initializer_types::Object;
@@ -22,7 +23,7 @@ use crate::{
 pub fn write_report(
     spec_container: &CapDLSpecContainer,
     kernel_config: &Config,
-    output_path: &str,
+    output_path: &Path,
 ) {
     let mut report_file = File::create(output_path).expect("Cannot create report file");
 

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -86,7 +86,7 @@ fn sdf_parse_number(s: &str, node: &roxmltree::Node) -> Result<u64, String> {
 }
 
 fn loc_string(xml_sdf: &XmlSystemDescription, pos: roxmltree::TextPos) -> String {
-    format!("{}:{}:{}", xml_sdf.filename, pos.row, pos.col)
+    format!("{}:{}:{}", xml_sdf.filename.display(), pos.row, pos.col)
 }
 
 #[repr(u8)]
@@ -1573,7 +1573,7 @@ impl Channel {
 }
 
 struct XmlSystemDescription<'a> {
-    filename: &'a str,
+    filename: &'a Path,
     doc: &'a roxmltree::Document<'a>,
 }
 
@@ -1669,7 +1669,7 @@ fn checked_lookup<'a>(
             "Error: Missing required attribute '{}' on element '{}': {}:{}:{}",
             attribute,
             node.tag_name().name(),
-            xml_sdf.filename,
+            xml_sdf.filename.display(),
             pos.row,
             pos.col
         ))
@@ -1682,7 +1682,7 @@ fn value_error(xml_sdf: &XmlSystemDescription, node: &roxmltree::Node, err: Stri
         "Error: {} on element '{}': {}:{}:{}",
         err,
         node.tag_name().name(),
-        xml_sdf.filename,
+        xml_sdf.filename.display(),
         pos.row,
         pos.col
     )
@@ -1797,14 +1797,14 @@ fn pd_flatten(
 }
 
 pub fn parse(
-    filename: &str,
+    filename: &Path,
     xml: &str,
     config: &Config,
     search_paths: &Vec<PathBuf>,
 ) -> Result<SystemDescription, String> {
     let doc = match roxmltree::Document::parse(xml) {
         Ok(doc) => doc,
-        Err(err) => return Err(format!("Could not parse '{filename}': {err}")),
+        Err(err) => return Err(format!("Could not parse '{0}': {err}", filename.display())),
     };
 
     let xml_sdf = XmlSystemDescription {
@@ -1949,7 +1949,7 @@ pub fn parse(
                     "Error: duplicate irq: {} in protection domain: '{}' @ {}:{}:{}",
                     sysirq.irq_num(),
                     pd.name,
-                    filename,
+                    filename.display(),
                     pd.text_pos.unwrap().row,
                     pd.text_pos.unwrap().col
                 ));
@@ -1968,7 +1968,7 @@ pub fn parse(
                     "Error: duplicate channel id: {} in protection domain: '{}' @ {}:{}:{}",
                     sysirq.id,
                     pd.name,
-                    filename,
+                    filename.display(),
                     pd.text_pos.unwrap().row,
                     pd.text_pos.unwrap().col
                 ));
@@ -1984,7 +1984,7 @@ pub fn parse(
                 "Error: duplicate channel id: {} in protection domain: '{}' @ {}:{}:{}",
                 ch.end_a.id,
                 pd.name,
-                filename,
+                filename.display(),
                 pd.text_pos.unwrap().row,
                 pd.text_pos.unwrap().col
             ));
@@ -1996,7 +1996,7 @@ pub fn parse(
                 "Error: duplicate channel id: {} in protection domain: '{}' @ {}:{}:{}",
                 ch.end_b.id,
                 pd.name,
-                filename,
+                filename.display(),
                 pd.text_pos.unwrap().row,
                 pd.text_pos.unwrap().col
             ));
@@ -2031,7 +2031,7 @@ pub fn parse(
                     "Error: duplicate I/O port id: {} in protection domain: '{}' @ {}:{}:{}",
                     ioport.id,
                     pd.name,
-                    filename,
+                    filename.display(),
                     pd.text_pos.unwrap().row,
                     pd.text_pos.unwrap().col
                 ));
@@ -2055,14 +2055,14 @@ pub fn parse(
                             left_range.start,
                             left_range.end,
                             pd.name,
-                            filename,
+                            filename.display(),
                             this_ioport.text_pos.row,
                             this_ioport.text_pos.col,
                             seen_ioport.id,
                             right_range.start,
                             right_range.end,
                             seen_pd_name,
-                            filename,
+                            filename.display(),
                             seen_ioport.text_pos.row,
                             seen_ioport.text_pos.col
                         ));

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -9,6 +9,7 @@ use microkit_tool::{
     sel4::{self},
 };
 use serde_json::json;
+use std::path::Path;
 
 const DEFAULT_AARCH64_KERNEL_CONFIG: sel4::Config = sel4::Config {
     arch: sel4::Arch::Aarch64,
@@ -68,7 +69,12 @@ fn check_success(kernel_config: &sel4::Config, test_name: &str) {
     path.push("tests/sdf/");
     path.push(test_name);
     let sdf = std::fs::read_to_string(path).unwrap();
-    let parse = sdf::parse(test_name, &sdf, kernel_config, &[prefill_path].to_vec());
+    let parse = sdf::parse(
+        Path::new(test_name),
+        &sdf,
+        kernel_config,
+        &[prefill_path].to_vec(),
+    );
 
     if let Err(ref e) = parse {
         eprintln!("Expected no error, instead got:\n{e}")
@@ -87,8 +93,13 @@ fn check_error(kernel_config: &sel4::Config, test_name: &str, expected_err: &str
     sdf_path.push("tests/sdf/");
     sdf_path.push(test_name);
     let sdf = std::fs::read_to_string(sdf_path).unwrap();
-    let parse_err =
-        sdf::parse(test_name, &sdf, kernel_config, &[prefill_path].to_vec()).unwrap_err();
+    let parse_err = sdf::parse(
+        Path::new(test_name),
+        &sdf,
+        kernel_config,
+        &[prefill_path].to_vec(),
+    )
+    .unwrap_err();
 
     if !parse_err.starts_with(expected_err) {
         eprintln!("Expected error:\n{expected_err}\nGot error:\n{parse_err}\n");


### PR DESCRIPTION
As part of a series of patches which upstream Viper export to Microkit, we separate argument parsing from `main.rs` into `argparse.rs`.

The code was refactored a bit to remove manual index manipulation. The user interface remains compatible/identical to the previous implementation.