### PR TITLE
tool: migrate to new environment info gathering

### DIFF
--- a/tool/microkit/src/argparse.rs
+++ b/tool/microkit/src/argparse.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
+use crate::sdk::Sdk;
 use std::fmt;
 use std::iter::Peekable;
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ pub fn print_usage() {
     println!("usage: microkit [-h] [OPTIONS] --board BOARD --config CONFIG [--search-path SEARCH_PATH ...] system")
 }
 
-pub fn print_help(available_boards: &[String]) {
+pub fn print_help(sdk: &Sdk) {
     print_usage();
     println!("\npositional arguments:");
     println!("  system");
@@ -22,7 +23,10 @@ pub fn print_help(available_boards: &[String]) {
     println!("  -r, --report REPORT");
     println!("  --image-type {{binary,elf,uimage}}");
     println!("  --override-kernel KERNEL (for debugging purposes)");
-    println!("  --board {}", available_boards.join("\n          "));
+    println!(
+        "  --board {}",
+        sdk.available_board_names().join("\n          ")
+    );
     println!("  --config CONFIG");
     println!("  --capdl-json CAPDL_SPEC (JSON format)");
     println!("  --search-path [SEARCH_PATH ...]");
@@ -73,11 +77,25 @@ pub struct Args {
 
 #[derive(Debug)]
 pub enum ArgsError {
-    InvalidImageTypeParameter { parameter: String },
-    InvalidBoardParameter { parameter: String },
-    MissingParameter { parent_argument: &'static str },
-    MissingRequiredArguments { args: Vec<&'static str> },
-    UnrecognizedArgument { arg: String },
+    InvalidImageTypeParameter {
+        parameter: String,
+    },
+    InvalidBoardParameter {
+        parameter: String,
+    },
+    InvalidConfigParameter {
+        parameter: String,
+        choices: Vec<String>,
+    },
+    MissingParameter {
+        parent_argument: &'static str,
+    },
+    MissingRequiredArguments {
+        args: Vec<&'static str>,
+    },
+    UnrecognizedArgument {
+        arg: String,
+    },
     HelpWanted,
 }
 
@@ -89,6 +107,13 @@ impl fmt::Display for ArgsError {
             }
             Self::InvalidBoardParameter { parameter } => {
                 write!(f, "argument --board: unknown parameter '{parameter}'")
+            }
+            Self::InvalidConfigParameter { parameter, choices } => {
+                write!(
+                    f,
+                    "argument --config: invalid choice '{parameter}' (choose from: {})",
+                    choices.join(", ")
+                )
             }
             Self::MissingParameter { parent_argument } => {
                 write!(f, "argument {parent_argument}: expected one parameter")
@@ -136,7 +161,7 @@ where
 }
 
 impl Args {
-    pub fn parse(args: &[String], available_boards: &[String]) -> Result<Self, ArgsError> {
+    pub fn parse(args: &[String], sdk: &Sdk) -> Result<Self, ArgsError> {
         let mut args = args.iter().skip(1).cloned().peekable();
 
         let mut output_path = PathBuf::from("loader.img");
@@ -163,7 +188,7 @@ impl Args {
                 }
                 "--board" => {
                     let board_param = consume_parameter(&mut args, "--board")?;
-                    if !available_boards.contains(&board_param) {
+                    if !sdk.available_boards_contains(&board_param) {
                         return Err(ArgsError::InvalidBoardParameter {
                             parameter: board_param,
                         });
@@ -223,6 +248,13 @@ impl Args {
         let board = board.unwrap();
         let config = config.unwrap();
         let sdf_path = sdf_path.unwrap();
+
+        if sdk.select(&board, &config).is_none() {
+            return Err(ArgsError::InvalidConfigParameter {
+                parameter: config,
+                choices: sdk.available_config_names_for(&board),
+            });
+        }
 
         Ok(Self {
             sdf_path,

--- a/tool/microkit/src/lib.rs
+++ b/tool/microkit/src/lib.rs
@@ -18,6 +18,7 @@ pub mod elf;
 pub mod loader;
 pub mod report;
 pub mod sdf;
+pub mod sdk;
 pub mod sel4;
 pub mod symbols;
 pub mod uimage;

--- a/tool/microkit/src/main.rs
+++ b/tool/microkit/src/main.rs
@@ -19,6 +19,7 @@ use microkit_tool::elf::ElfFile;
 use microkit_tool::loader::Loader;
 use microkit_tool::report::write_report;
 use microkit_tool::sdf::{parse, SysMemoryRegion, SysMemoryRegionPaddr};
+use microkit_tool::sdk::Sdk;
 use microkit_tool::sel4::{
     emulate_kernel_boot, emulate_kernel_boot_partial, Arch, Config, PlatformConfig,
     RiscvVirtualMemory,
@@ -82,54 +83,31 @@ impl ImageOutputType {
     }
 }
 
+fn bail_if_not_exists(description: &'static str, path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        eprintln!(
+            "microkit: error: {description} '{}' does not exist",
+            path.display()
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), String> {
-    let exe_path = std::env::current_exe().unwrap();
-    let sdk_env = std::env::var("MICROKIT_SDK");
-    let sdk_dir = match sdk_env {
-        Ok(ref value) => Path::new(value),
-        Err(err) => match err {
-            // If there is no MICROKIT_SDK explicitly set, use the one that the binary is in.
-            std::env::VarError::NotPresent => exe_path.parent().unwrap().parent().unwrap(),
-            _ => {
-                return Err(format!(
-                    "Could not read MICROKIT_SDK environment variable: {err}"
-                ))
-            }
-        },
+    let sdk = match Sdk::discover() {
+        Ok(discovered_info) => discovered_info,
+        Err(err) => {
+            eprintln!("microkit: error: {err}");
+            std::process::exit(1);
+        }
     };
 
-    if !sdk_dir.exists() {
-        eprintln!(
-            "Error: SDK directory '{}' does not exist.",
-            sdk_dir.display()
-        );
-        std::process::exit(1);
-    }
-
-    let boards_path = sdk_dir.join("board");
-    if !boards_path.exists() || !boards_path.is_dir() {
-        eprintln!(
-            "Error: SDK directory '{}' does not have a 'board' sub-directory.",
-            sdk_dir.display()
-        );
-        std::process::exit(1);
-    }
-
-    let mut available_boards = Vec::new();
-    for p in fs::read_dir(&boards_path).unwrap() {
-        let path_buf = p.unwrap().path();
-        let path = path_buf.as_path();
-        if path.is_dir() {
-            available_boards.push(path.file_name().unwrap().to_str().unwrap().to_string());
-        }
-    }
-    available_boards.sort();
-
     let env_args: Vec<_> = std::env::args().collect();
-    let mut args = match Args::parse(&env_args, &available_boards) {
-        Ok(result) => result,
+    let mut args = match Args::parse(&env_args, &sdk) {
+        Ok(parsed_arguments) => parsed_arguments,
         Err(ArgsError::HelpWanted) => {
-            argparse::print_help(&available_boards);
+            argparse::print_help(&sdk);
             std::process::exit(0);
         }
         Err(err) => {
@@ -146,42 +124,12 @@ fn main() -> Result<(), String> {
     };
     args.search_paths.push(std::env::current_dir().unwrap());
 
-    let board_path = boards_path.join(&args.board);
-    if !board_path.exists() {
-        eprintln!(
-            "Error: board path '{}' does not exist.",
-            board_path.display()
-        );
-        std::process::exit(1);
-    }
+    // NB safe unwrap: argparse would already have bailed if the config did not
+    // exist.
+    let current_config = sdk.select(&args.board, &args.config).unwrap();
 
-    let mut available_configs = Vec::new();
-    for p in fs::read_dir(board_path).unwrap() {
-        let path_buf = p.unwrap().path();
-        let path = path_buf.as_path();
-
-        if path.file_name().unwrap() == "example" {
-            continue;
-        }
-
-        if path.is_dir() {
-            available_configs.push(path.file_name().unwrap().to_str().unwrap().to_string());
-        }
-    }
-
-    if !available_configs.contains(&args.config.to_string()) {
-        eprintln!(
-            "microkit: error: argument --config: invalid choice: '{}' (choose from: {})",
-            args.config,
-            available_configs.join(", ")
-        )
-    }
-
-    let elf_path = sdk_dir
-        .join("board")
-        .join(&args.board)
-        .join(&args.config)
-        .join("elf");
+    // the real work begins here
+    let elf_path = current_config.config_dir.join("elf");
     let loader_elf_path = elf_path.join("loader.elf");
     let kernel_elf_path = match args.override_kernel {
         Some(ref path) => path,
@@ -189,70 +137,19 @@ fn main() -> Result<(), String> {
     };
     let monitor_elf_path = elf_path.join("monitor.elf");
     let capdl_init_elf_path = elf_path.join("initialiser.elf");
-
-    let kernel_config_path = sdk_dir
-        .join("board")
-        .join(&args.board)
-        .join(&args.config)
+    let kernel_config_path = current_config
+        .config_dir
         .join("include/kernel/gen_config.json");
-
-    let invocations_all_path = sdk_dir
-        .join("board")
-        .join(&args.board)
-        .join(&args.config)
-        .join("invocations_all.json");
-
-    if !elf_path.exists() {
-        eprintln!(
-            "Error: board ELF directory '{}' does not exist",
-            elf_path.display()
-        );
-        std::process::exit(1);
-    }
-    if !kernel_elf_path.exists() {
-        eprintln!(
-            "Error: kernel ELF '{}' does not exist",
-            kernel_elf_path.display()
-        );
-        std::process::exit(1);
-    }
-    if !monitor_elf_path.exists() {
-        eprintln!(
-            "Error: monitor ELF '{}' does not exist",
-            monitor_elf_path.display()
-        );
-        std::process::exit(1);
-    }
-    if !capdl_init_elf_path.exists() {
-        eprintln!(
-            "Error: CapDL initialiser ELF '{}' does not exist",
-            capdl_init_elf_path.display()
-        );
-        std::process::exit(1);
-    }
-    if !kernel_config_path.exists() {
-        eprintln!(
-            "Error: kernel configuration file '{}' does not exist",
-            kernel_config_path.display()
-        );
-        std::process::exit(1);
-    }
-    if !invocations_all_path.exists() {
-        eprintln!(
-            "Error: invocations JSON file '{}' does not exist",
-            invocations_all_path.display()
-        );
-        std::process::exit(1);
-    }
+    let invocations_all_path = current_config.config_dir.join("invocations_all.json");
+    bail_if_not_exists("board ELF directory", &elf_path)?;
+    bail_if_not_exists("kernel ELF", kernel_elf_path)?;
+    bail_if_not_exists("monitor ELF", &monitor_elf_path)?;
+    bail_if_not_exists("CapDL initialiser ELF", &capdl_init_elf_path)?;
+    bail_if_not_exists("kernel configuration file", &kernel_config_path)?;
+    bail_if_not_exists("invocations JSON file", &invocations_all_path)?;
 
     let system_path = &args.sdf_path;
-    if !system_path.exists() {
-        eprintln!(
-            "Error: system description file '{}' does not exist",
-            system_path.display()
-        );
-        std::process::exit(1);
-    }
+    bail_if_not_exists("system description file", system_path)?;
 
     let xml: String = fs::read_to_string(system_path).unwrap();
 
@@ -287,23 +184,10 @@ fn main() -> Result<(), String> {
     let (device_regions, normal_regions) = match arch {
         Arch::X86_64 => (None, None),
         _ => {
-            let kernel_platform_config_path = sdk_dir
-                .join("board")
-                .join(&args.board)
-                .join(&args.config)
-                .join("platform_gen.json");
-
-            if !kernel_platform_config_path.exists() {
-                eprintln!(
-                    "Error: kernel platform configuration file '{}' does not exist",
-                    kernel_platform_config_path.display()
-                );
-                std::process::exit(1);
-            }
-
+            let platform_gen_path = current_config.config_dir.join("platform_gen.json");
+            bail_if_not_exists("kernel platform configuration file", &platform_gen_path)?;
             let kernel_platform_config: PlatformConfig =
-                serde_json::from_str(&fs::read_to_string(kernel_platform_config_path).unwrap())
-                    .unwrap();
+                serde_json::from_str(&fs::read_to_string(platform_gen_path).unwrap()).unwrap();
 
             (
                 Some(kernel_platform_config.devices),
@@ -313,19 +197,8 @@ fn main() -> Result<(), String> {
     };
 
     let object_sizes = {
-        let object_sizes_path = sdk_dir
-            .join("board")
-            .join(args.board)
-            .join(&args.config)
-            .join("object_sizes.json");
-
-        if !object_sizes_path.exists() {
-            eprintln!(
-                "Error: object sizes file '{}' does not exist",
-                object_sizes_path.display()
-            );
-            std::process::exit(1);
-        }
+        let object_sizes_path = current_config.config_dir.join("object_sizes.json");
+        bail_if_not_exists("kernel object sizes file", &object_sizes_path)?;
 
         serde_json::from_str(&fs::read_to_string(object_sizes_path).unwrap()).unwrap()
     };

--- a/tool/microkit/src/sdk.rs
+++ b/tool/microkit/src/sdk.rs
@@ -1,0 +1,254 @@
+//
+// Copyright 2025, UNSW
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+use std::env::{self, VarError};
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct BoardInfo {
+    pub name: String,
+    pub dir: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct AvailableConfig {
+    pub board_name: String,
+    pub board_dir: PathBuf,
+    pub config_name: String,
+    pub config_dir: PathBuf,
+}
+
+pub struct Sdk {
+    pub exe_path: PathBuf,
+    pub cwd: PathBuf,
+    pub available_boards: Vec<BoardInfo>,
+    pub available_configs: Vec<AvailableConfig>,
+}
+
+#[derive(Debug)]
+pub enum SdkError {
+    CannotDetermineExePath { source: io::Error },
+    CannotDetermineCwd { source: io::Error },
+    CannotReadSdkVar { source: VarError },
+    CannotInferSdkDir { exe_path: PathBuf },
+    CannotFindSdkDirectory { path: PathBuf },
+    CannotFindBoardsDirectory { path: PathBuf },
+    CannotFindDirectory { path: PathBuf },
+    CannotReadDirectory { path: PathBuf, source: io::Error },
+}
+
+impl fmt::Display for SdkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CannotDetermineExePath { source } => {
+                write!(
+                    f,
+                    "Could not determine the current executable path: {source}"
+                )
+            }
+            Self::CannotDetermineCwd { source } => {
+                write!(
+                    f,
+                    "Could not determine the current working directory: {source}"
+                )
+            }
+            Self::CannotReadSdkVar { source } => {
+                write!(
+                    f,
+                    "Could not read the MICROKIT_SDK environmental variable: {source}"
+                )
+            }
+            Self::CannotFindSdkDirectory { path } => {
+                write!(
+                    f,
+                    "The MICROKIT_SDK directory '{}' does not exist",
+                    path.display()
+                )
+            }
+            Self::CannotFindBoardsDirectory { path } => {
+                write!(
+                    f,
+                    "The SDK directory does not have a 'board' sub-directory at '{}'",
+                    path.display()
+                )
+            }
+            Self::CannotInferSdkDir { exe_path } => {
+                write!(
+                    f,
+                    "No SDK directory specified and cannot infer SDK directory from executable path '{}'",
+                    exe_path.display()
+                )
+            }
+            Self::CannotFindDirectory { path } => {
+                write!(f, "The directory '{}' does not exist", path.display())
+            }
+            Self::CannotReadDirectory { path, source } => {
+                write!(
+                    f,
+                    "The directory '{}' could not be read: {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+fn read_dir(path: &Path) -> Result<fs::ReadDir, SdkError> {
+    match fs::read_dir(path) {
+        Ok(result) => Ok(result),
+        Err(ioerr) => Err(SdkError::CannotReadDirectory {
+            path: path.to_path_buf(),
+            source: ioerr,
+        }),
+    }
+}
+
+fn read_dir_entry(
+    path: &Path,
+    entry: Result<fs::DirEntry, io::Error>,
+) -> Result<fs::DirEntry, SdkError> {
+    match entry {
+        Ok(result) => Ok(result),
+        Err(ioerr) => Err(SdkError::CannotReadDirectory {
+            path: path.to_path_buf(),
+            source: ioerr,
+        }),
+    }
+}
+
+fn final_path_component(path: &Path) -> Result<&str, SdkError> {
+    path.file_name()
+        .and_then(|component| component.to_str())
+        .ok_or(SdkError::CannotFindDirectory {
+            path: path.to_path_buf(),
+        })
+}
+
+fn discover_sdk_dir(default_path: &Path) -> Result<PathBuf, SdkError> {
+    match env::var("MICROKIT_SDK") {
+        Ok(value) => {
+            // happy path, MICROKIT_SDK is set
+            let path = PathBuf::from(value);
+            if path.exists() && path.is_dir() {
+                Ok(path)
+            } else {
+                Err(SdkError::CannotFindSdkDirectory { path })
+            }
+        }
+        Err(VarError::NotPresent) => {
+            // there is no MICROKIT_SDK explicitly set, use the one that the binary is in
+            let grandpa = Some(default_path)
+                .and_then(|p| p.parent())
+                .and_then(|p| p.parent());
+            match grandpa {
+                Some(gp) => Ok(gp.to_path_buf()),
+                None => Err(SdkError::CannotInferSdkDir {
+                    exe_path: default_path.to_path_buf(),
+                }),
+            }
+        }
+        Err(source) => {
+            // something goes very wrong while reading env variables
+            Err(SdkError::CannotReadSdkVar { source })
+        }
+    }
+}
+
+fn discover_boards(dir: &Path) -> Result<Vec<BoardInfo>, SdkError> {
+    let entries = read_dir(dir)?;
+    let mut discovered = Vec::new();
+    for entry in entries {
+        let entry = read_dir_entry(dir, entry)?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = final_path_component(&path)?.to_owned();
+        let board = BoardInfo { name, dir: path };
+        discovered.push(board);
+    }
+    Ok(discovered)
+}
+
+fn discover_available_configs_for(board: &BoardInfo) -> Result<Vec<AvailableConfig>, SdkError> {
+    let entries = read_dir(&board.dir)?;
+    let mut discovered = Vec::new();
+    for entry in entries {
+        // TODO: we should defer this check if possible, so that we don't
+        // bail when some irrelevant board has a permission error
+        let entry = read_dir_entry(&board.dir, entry)?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = final_path_component(&path)?.to_owned();
+        let config = AvailableConfig {
+            board_name: board.name.clone(),
+            board_dir: board.dir.clone(),
+            config_name: name,
+            config_dir: path.to_path_buf(),
+        };
+        discovered.push(config);
+    }
+    Ok(discovered)
+}
+
+impl Sdk {
+    pub fn discover() -> Result<Self, SdkError> {
+        let exe_path =
+            env::current_exe().map_err(|source| SdkError::CannotDetermineExePath { source })?;
+        let cwd = env::current_dir().map_err(|source| SdkError::CannotDetermineCwd { source })?;
+        let sdk_dir = discover_sdk_dir(&exe_path)?;
+        let boards_dir = sdk_dir.join("board");
+        if !boards_dir.exists() || !boards_dir.is_dir() {
+            return Err(SdkError::CannotFindBoardsDirectory { path: boards_dir });
+        }
+
+        let mut available_boards = discover_boards(&boards_dir)?;
+        available_boards.sort_by_key(|b| b.name.clone());
+
+        let mut available_configs: Vec<AvailableConfig> = Vec::new();
+
+        for board in &available_boards {
+            available_configs.append(&mut discover_available_configs_for(board)?);
+        }
+
+        Ok(Self {
+            exe_path,
+            cwd,
+            available_boards,
+            available_configs,
+        })
+    }
+
+    pub fn select(&self, board_name: &str, config_name: &str) -> Option<&AvailableConfig> {
+        self.available_configs
+            .iter()
+            .find(|pair| pair.board_name == board_name && pair.config_name == config_name)
+    }
+
+    pub fn available_boards_contains(&self, name: &str) -> bool {
+        self.available_boards.iter().any(|b| b.name == name)
+    }
+
+    pub fn available_board_names(&self) -> Vec<String> {
+        self.available_boards
+            .iter()
+            .map(|b| b.name.clone())
+            .collect()
+    }
+
+    pub fn available_config_names_for(&self, board_name: &str) -> Vec<String> {
+        self.available_configs
+            .iter()
+            .filter(|c| c.board_name == board_name)
+            .map(|c| c.config_name.clone())
+            .collect()
+    }
+}


### PR DESCRIPTION
As part of a series of patches which upstream Viper export to Microkit, we separate SDK environment discovery from `main.rs` into `sdk.rs`.

SDK discovery is the following process:
1. finding the location of the Microkit directory based on the `MICROKIT_SDK` env variable, or if that's not set then based on the location of the tool executable itself)
2. finding the list of available boards and configs (`debug`/`release`/etc.)

This has to happen before argument parsing, and lets us give better error messages (e.g. we can report available configs if an invalid `--config` argument is given).