### PR TITLE
loader: fix mismatched type for inline assembly

### DIFF
--- a/loader/src/aarch64/init.c
+++ b/loader/src/aarch64/init.c
@@ -137,7 +137,7 @@ typedef void (*sel4_entry)(
 void arch_jump_to_kernel(int logical_cpu)
 {
     /* seL4 always expects the current logical CPU number in TPIDR_EL1 */
-    asm volatile("msr TPIDR_EL1, %0" :: "r"(logical_cpu));
+    asm volatile("msr TPIDR_EL1, %0" :: "r"((uint64_t) logical_cpu));
     asm volatile("isb" ::: "memory");
 
     ((sel4_entry)(loader_data->kernel_entry))(


### PR DESCRIPTION
This fixes the following warning when using the llvm toolchain
```
src/aarch64/init.c:140:45: error: value size does not match register size specified by the constraint and modifier [-Werror,-Wasm-operand-widths]
  140 |     asm volatile("msr TPIDR_EL1, %0" :: "r"(logical_cpu));
      |                                             ^
src/aarch64/init.c:140:34: note: use constraint modifier "w"
  140 |     asm volatile("msr TPIDR_EL1, %0" :: "r"(logical_cpu));
      |                                  ^~
      |                                  %w0
1 error generated.
```