### PR TITLE
ci: fix github ssh deploy key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -245,4 +245,4 @@ jobs:
         manifest_repo: seL4/microkit-manifest
         manifest_branch: main
       env:
-        GH_SSH: ${{ secrets.GH_SSH }}
+        GH_SSH: ${{ secrets.CI_SSH }}


### PR DESCRIPTION
The one we use in the org keys is called CI_SSH, not GH_SSH.