### PR TITLE
Update rust-sel4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sel4"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "cfg-if",
  "sel4-config",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "sel4-alloca"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "cfg-if",
 ]
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "sel4-bitfield-ops"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "rustversion",
 ]
@@ -520,12 +520,12 @@ dependencies = [
 [[package]]
 name = "sel4-build-env"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-capdl-initializer"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "log",
  "rkyv",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "miniz_oxide",
  "rkyv",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types-derive"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "sel4-config"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-data"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "sel4-build-env",
  "sel4-config-types",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "fallible-iterator",
  "proc-macro2",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-types"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "serde",
 ]
@@ -607,12 +607,12 @@ dependencies = [
 [[package]]
 name = "sel4-ctors-dtors"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-dlmalloc"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "dlmalloc",
  "lock_api",
@@ -621,22 +621,22 @@ dependencies = [
 [[package]]
 name = "sel4-elf-header"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-immediate-sync-once-cell"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-immutable-cell"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-initialize-tls"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "cfg-if",
  "sel4-alloca",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "sel4-logging"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "lock_api",
  "log",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "sel4-panicking"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "cfg-if",
  "sel4-immediate-sync-once-cell",
@@ -665,12 +665,12 @@ dependencies = [
 [[package]]
 name = "sel4-panicking-env"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-root-task"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "sel4",
  "sel4-dlmalloc",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "sel4-root-task-macros"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "sel4-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -710,12 +710,12 @@ dependencies = [
 [[package]]
 name = "sel4-stack"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 
 [[package]]
 name = "sel4-sync"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "lock_api",
  "sel4",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "sel4-sys"
 version = "0.1.0"
-source = "git+https://github.com/au-ts/rust-sel4?rev=9102a134c2b5925d17e021280a3d104e79805221#9102a134c2b5925d17e021280a3d104e79805221"
+source = "git+https://github.com/au-ts/rust-sel4?rev=33cb132571121a8d846ad3be9066617087ee5c32#33cb132571121a8d846ad3be9066617087ee5c32"
 dependencies = [
  "bindgen",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ members = [
 
 [workspace.dependencies.sel4-capdl-initializer]
 git = "https://github.com/au-ts/rust-sel4"
-rev = "9102a134c2b5925d17e021280a3d104e79805221"
+rev = "33cb132571121a8d846ad3be9066617087ee5c32"
 
 [workspace.dependencies.sel4-capdl-initializer-types]
 git = "https://github.com/au-ts/rust-sel4"
-rev = "9102a134c2b5925d17e021280a3d104e79805221"
+rev = "33cb132571121a8d846ad3be9066617087ee5c32"
 
 [profile.release.package.microkit-tool]
 strip = true


### PR DESCRIPTION
rust-sel4 branch: [microkit-2.2.0-dev](https://github.com/au-ts/rust-sel4/tree/microkit-2.2.0-dev)

Hot fix 2 issues:
- Fixed compile error in rust-sel4 when 1GB huge page support is disabled in the kernel. In some environments such as cloud VMs or older machines this won't be available. Fixes https://github.com/seL4/microkit/issues/505.

- Fixed `https://github.com/seL4/rust-sel4/issues/319`. Placed it in back tick so that merging this PR won't close that issue.

These will need to be upstreamed to rust-sel4.