### PR TITLE
tool: generate page tables for EL1 support

### DIFF
--- a/tool/microkit/src/loader.rs
+++ b/tool/microkit/src/loader.rs
@@ -870,11 +870,14 @@ impl<'a> Loader<'a> {
             boot_lvl2_lower[start..end].copy_from_slice(&pt_entry.to_le_bytes());
         }
 
-        let boot_lvl0_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
+        let mut boot_lvl0_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];
         {
             let pt_entry = aarch64::table_descriptor(boot_lvl1_upper_addr);
             let idx = aarch64::lvl0_index(first_vaddr);
+            // For EL2.
             boot_lvl0_lower[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry.to_le_bytes());
+            // For EL1.
+            boot_lvl0_upper[8 * idx..8 * (idx + 1)].copy_from_slice(&pt_entry.to_le_bytes());
         }
 
         let mut boot_lvl1_upper: [u8; PAGE_TABLE_SIZE] = [0; PAGE_TABLE_SIZE];


### PR DESCRIPTION
This is as per the documentation given above the function, just for some reason only lvl0_lower ever had anything placed in it. This makes the code dual-use for hypervisor/not.