### PR TITLE
manual: update copyright to seL4 International

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -248,7 +248,7 @@ domains, the attributes used for different mappings may vary.
 ### Prefilling
 
 A *memory region* may be prefilled with data from a file at build time
-by specifying the file's name in the [System Description File]{#sysdesc}.
+by specifying the file's name in the [System Description File](#sysdesc).
 
 In this case, specifying the memory region's size become optional. If
 a size isn't specified, the memory region will be sized by the length

--- a/docs/style/sel4.sty
+++ b/docs/style/sel4.sty
@@ -1,4 +1,4 @@
-% Copyright seL4 Project a Series of LF Projects, LLC
+% Copyright seL4 International
 % SPDX-License-Identifier: CC-BY-SA-4.0
 
 \NeedsTeXFormat{LaTeX2e}
@@ -143,7 +143,7 @@
   \let\@makefnmark\relax%
   \footnote{%
     \hspace*{-1.8em}%    Magic number from article.cls/report.cls
-    Copyright \copyright~#1 seL4 Project a Series of LF Projects, LLC.\\
+    Copyright \copyright~#1 seL4 International.\\
     Distributed under the
     \href{https://creativecommons.org/licenses/by-sa/4.0/legalcode}{Creative
       Commons Attribution-ShareAlike 4.0 International (CC~BY-SA~4.0) License.}\\


### PR DESCRIPTION
Also fix an issue with the hyperlink to system description files.