### PR TITLE
Rename to microkit_cspace_root_slot_to_cptr

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -984,7 +984,7 @@ virtual CPU with ID `vcpu`.
 Write the registers of a given virtual CPU with ID `vcpu`. The `regs` argument is the pointer to
 the struct of registers `seL4_VCPUContext` that are written from.
 
-## `seL4_CPtr microkit_cspace_slot_to_cptr(seL4_Word slot)` {#libmicrokit_cspace_slot_to_cptr}
+## `seL4_CPtr microkit_cspace_root_slot_to_cptr(seL4_Word slot)` {#libmicrokit_cspace_root_slot_to_cptr}
 
 Converts the slot identifier of the `<cspace>`'s capability element into an
 `seL4_CPtr` value to be used in `libsel4` calls by the PD.
@@ -1148,7 +1148,7 @@ It supports no attributes, but supports the following elements as children:
 * `cap_cspace`: A capability to a protection domain's CSpace.
 
 All of the elements support the `slot` attribute, which is is an opaque identifier used to address the capability at runtime.
-To convert the `slot` to an `seL4_CPtr`, use the [`seL4_CPtr microkit_cspace_slot_to_cptr(seL4_Word slot)`](#libmicrokit_cspace_slot_to_cptr) function.
+To convert the `slot` to an `seL4_CPtr`, use the [`seL4_CPtr microkit_cspace_root_slot_to_cptr(seL4_Word slot)`](#libmicrokit_cspace_root_slot_to_cptr) function.
 
 See the 'cap_sharing' example packaged in your SDK or [on GitHub](https://github.com/seL4/microkit/tree/main/example/cap_sharing).
 

--- a/example/cap_sharing/cap_sharing.c
+++ b/example/cap_sharing/cap_sharing.c
@@ -9,10 +9,10 @@
 #define CH_SECONDARY ((microkit_channel)0)
 
 // As per cap_sharing.system
-#define CAP_SECONDARY_SC  (microkit_cspace_slot_to_cptr(1))
-#define CAP_SECONDARY_TCB (microkit_cspace_slot_to_cptr(2))
-#define CAP_MY_SC         (microkit_cspace_slot_to_cptr(3))
-#define CAP_MY_TCB        (microkit_cspace_slot_to_cptr(4))
+#define CAP_SECONDARY_SC  (microkit_cspace_root_slot_to_cptr(1))
+#define CAP_SECONDARY_TCB (microkit_cspace_root_slot_to_cptr(2))
+#define CAP_MY_SC         (microkit_cspace_root_slot_to_cptr(3))
+#define CAP_MY_TCB        (microkit_cspace_root_slot_to_cptr(4))
 
 static void halt(void)
 {

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -516,7 +516,7 @@ static inline void microkit_deferred_irq_ack(microkit_channel ch)
  * If the slot exceeds the valid range of inputs (0 <= slot < MICROKIT_MAX_USER_CAPS),
  * it returns the value `seL4_CapNull`.
  **/
-static inline seL4_CPtr microkit_cspace_slot_to_cptr(seL4_Word slot)
+static inline seL4_CPtr microkit_cspace_root_slot_to_cptr(seL4_Word slot)
 {
     if (slot > MICROKIT_MAX_USER_CAPS) {
         return seL4_CapNull;


### PR DESCRIPTION
This reflects the intended usecase of this.