### PR TITLE
Add bootinfo tag

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -19,7 +19,7 @@ on:
       - '*.*.*'
 
 env:
-  SEL4_VERSION: c8526a426f150bc11474ef21449efd87c5b8b6e3
+  SEL4_VERSION: b7ef16a42d6d87b776462e66b8803365aea9f41d
 
 # To reduce the load we cancel any older runs of this workflow for the current
 # PR. For deployment to the main branch, the workflow will run on each push,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bytecheck"
@@ -102,39 +93,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "dlmalloc"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if",
  "libc",
@@ -143,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "fallible-iterator"
@@ -154,20 +116,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 
 [[package]]
 name = "glob"
@@ -177,9 +129,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "initialiser"
@@ -199,15 +151,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -230,15 +182,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microkit-tool"
@@ -298,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -308,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -318,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -331,12 +283,11 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -351,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -380,27 +331,27 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -410,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -421,24 +372,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.8.12"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a640b26f007713818e9a9b65d34da1cf58538207b052916a83d80e43f3ffa4"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -452,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.12"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -469,21 +420,15 @@ checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -494,7 +439,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sel4"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "cfg-if",
  "sel4-config",
@@ -504,7 +449,7 @@ dependencies = [
 [[package]]
 name = "sel4-alloca"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "cfg-if",
 ]
@@ -512,7 +457,7 @@ dependencies = [
 [[package]]
 name = "sel4-bitfield-ops"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "rustversion",
 ]
@@ -520,12 +465,12 @@ dependencies = [
 [[package]]
 name = "sel4-build-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-capdl-initializer"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "log",
  "rkyv",
@@ -543,7 +488,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "miniz_oxide",
  "rkyv",
@@ -555,7 +500,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types-derive"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -565,7 +510,7 @@ dependencies = [
 [[package]]
 name = "sel4-config"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -579,7 +524,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-data"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "sel4-build-env",
  "sel4-config-types",
@@ -589,7 +534,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "fallible-iterator",
  "proc-macro2",
@@ -602,7 +547,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "serde",
 ]
@@ -610,12 +555,12 @@ dependencies = [
 [[package]]
 name = "sel4-ctors-dtors"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-dlmalloc"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "dlmalloc",
  "lock_api",
@@ -624,17 +569,17 @@ dependencies = [
 [[package]]
 name = "sel4-immediate-sync-once-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-immutable-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-initialize-tls"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "cfg-if",
  "sel4-alloca",
@@ -643,7 +588,7 @@ dependencies = [
 [[package]]
 name = "sel4-logging"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "lock_api",
  "log",
@@ -652,12 +597,12 @@ dependencies = [
 [[package]]
 name = "sel4-no-allocator"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-panicking"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "cfg-if",
  "sel4-immediate-sync-once-cell",
@@ -668,12 +613,12 @@ dependencies = [
 [[package]]
 name = "sel4-panicking-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-phdrs"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "sel4-phdrs-constants",
 ]
@@ -681,12 +626,12 @@ dependencies = [
 [[package]]
 name = "sel4-phdrs-constants"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-phdrs-patched"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "sel4-phdrs",
  "sel4-rodata-static",
@@ -695,12 +640,12 @@ dependencies = [
 [[package]]
 name = "sel4-rodata-static"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-root-task"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "sel4",
  "sel4-dlmalloc",
@@ -715,7 +660,7 @@ dependencies = [
 [[package]]
 name = "sel4-root-task-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -725,7 +670,7 @@ dependencies = [
 [[package]]
 name = "sel4-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -741,12 +686,12 @@ dependencies = [
 [[package]]
 name = "sel4-stack"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 
 [[package]]
 name = "sel4-sync"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "lock_api",
  "sel4",
@@ -756,7 +701,7 @@ dependencies = [
 [[package]]
 name = "sel4-sys"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+source = "git+https://github.com/seL4/rust-sel4?rev=2541371f62dd097f7d47127125c44a0922145fa5#2541371f62dd097f7d47127125c44a0922145fa5"
 dependencies = [
  "bindgen",
  "glob",
@@ -807,26 +752,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "zmij",
 ]
 
 [[package]]
@@ -843,9 +777,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -854,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -868,12 +802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,24 +809,18 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unwinding"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60612c845ef41699f39dc8c5391f252942c0a88b7d15da672eff0d14101bbd6d"
+checksum = "8ac8808f11429cd2a9323c960cfca5f3da45bcc5717cc82f51721a3f2213056d"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"
@@ -908,83 +830,18 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "xml"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xmltree"
@@ -994,3 +851,9 @@ checksum = "cbc04313cab124e498ab1724e739720807b6dc405b9ed0edc5860164d2e4ff70"
 dependencies = [
  "xml",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ members = [
 
 [workspace.dependencies.sel4-capdl-initializer]
 git = "https://github.com/seL4/rust-sel4"
-rev = "c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+rev = "2541371f62dd097f7d47127125c44a0922145fa5"
 
 [workspace.dependencies.sel4-capdl-initializer-types]
 git = "https://github.com/seL4/rust-sel4"
-rev = "c30d0e44fb32c15239049ce402ef2a8c72499aa3"
+rev = "2541371f62dd097f7d47127125c44a0922145fa5"
 
 [profile.release.package.microkit-tool]
 strip = true

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -255,6 +255,17 @@ a size isn't specified, the memory region will be sized by the length
 of the prefill file, rounded up to the smallest page size or the user
 specified page size.
 
+A *memory region* can also be prefilled with bootinfo by the capDL Initialiser
+via the parameter `prefill_bootinfo` in the [System Description File](#sysdesc).
+If a size isn't specified, the memory region defaults to a single smallest page.
+The supported bootinfo types include:
+
+* `x86_vbe`
+* `x86_mbmap`
+* `x86_acpi_rsdp`
+* `x86_framebuffer`
+* `x86_tsc_freq`
+
 ## Channels {#channels}
 
 A *channel* enables two protection domains to interact using protected procedures or notifications.
@@ -1037,6 +1048,7 @@ It supports the following attributes:
 * `page_size`: (optional) Size of the pages used in the memory region; must be a supported page size if provided. Defaults to the largest page size for the target architecture that the memory region is aligned to.
 * `phys_addr`: (optional) The physical address for the start of the memory region (must be a multiple of the page size).
 * `prefill_path`: (optional) Path to a file containing data that the memory region will be filled with at initialisation.
+* `prefill_bootinfo`: (optional) Bootinfo type that the memmory region will be filled with by the capDL initialiser.
 
 The `memory_region` element does not support any child elements.
 

--- a/example/bootinfo/Makefile
+++ b/example/bootinfo/Makefile
@@ -1,0 +1,80 @@
+#
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+ifeq ($(strip $(BUILD_DIR)),)
+$(error BUILD_DIR must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_CONFIG)),)
+$(error MICROKIT_CONFIG must be specified)
+endif
+
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+
+ARCH := ${shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4}
+
+ifeq ($(ARCH),x86_64)
+	TARGET_TRIPLE := x86_64-linux-gnu
+	CFLAGS_ARCH := -march=x86-64 -mtune=generic
+  KERNEL := $(BOARD_DIR)//elf/sel4.elf
+  KERNEL_32B := $(BOARD_DIR)//elf/sel4_32.elf
+else
+$(error Unsupported ARCH)
+endif
+
+ifeq ($(strip $(LLVM)),True)
+  CC := clang -target $(TARGET_TRIPLE)
+  AS := clang -target $(TARGET_TRIPLE)
+  LD := ld.lld
+else
+  CC := $(TARGET_TRIPLE)-gcc
+  LD := $(TARGET_TRIPLE)-ld
+  AS := $(TARGET_TRIPLE)-as
+endif
+
+MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+
+IMAGES := bootinfo.elf
+CFLAGS := -nostdlib -ffreestanding -g -O3 -Wall  -Wno-unused-function -Werror -I$(BOARD_DIR)/include $(CFLAGS_ARCH)
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := -lmicrokit -Tmicrokit.ld
+
+IMAGE_FILE = $(BUILD_DIR)/loader.img
+REPORT_FILE = $(BUILD_DIR)/report.txt
+
+all: $(IMAGE_FILE)
+
+$(BUILD_DIR):
+	mkdir -p $@
+
+$(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD_DIR)/%.elf: $(BUILD_DIR)/%.o
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+$(IMAGE_FILE) $(REPORT_FILE): $(addprefix $(BUILD_DIR)/, $(IMAGES)) bootinfo.system
+	$(MICROKIT_TOOL) bootinfo.system --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
+
+qemu: $(IMAGE_FILE) $(KERNEL_32B)
+ifeq ($(ARCH),x86_64)
+	qemu-system-x86_64                      \
+			-cpu qemu64,+fsgsbase,+pdpe1gb,+xsaveopt,+xsave \
+			-m "1G"                         \
+			-display none                   \
+			-serial mon:stdio               \
+		-kernel $(KERNEL_32B)             \
+		-initrd $(IMAGE_FILE)
+else
+$(error Unsupported ARCH)
+endif

--- a/example/bootinfo/README.md
+++ b/example/bootinfo/README.md
@@ -1,0 +1,30 @@
+<!--
+     Copyright 2026, UNSW
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+# Example - Hello World
+
+This is a basic example that demonstrates how one can define
+a MemoryRegion prefilled with BootInfo and map it to a PD, so
+the PD can read the BootInfo in userland.
+
+Supported BootInfo includes:
+- x86_vbe
+- x86_mbmap
+- x86_acpi_rsdp
+- x86_framebuffer
+- x86_tsc_freq
+
+As Microkit loader does not pass the DTB through on ARM and RISC-V,
+so only x86 is supported in this example for now.
+
+## Building
+
+```sh
+mkdir build
+make BUILD_DIR=build MICROKIT_BOARD=<board> MICROKIT_CONFIG=<debug/release/benchmark> MICROKIT_SDK=/path/to/sdk qemu
+```
+
+## Running
+
+See instructions for your board in the manual.

--- a/example/bootinfo/bootinfo.c
+++ b/example/bootinfo/bootinfo.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <stdint.h>
+#include <microkit.h>
+
+#if defined(CONFIG_ARCH_X86_64)
+typedef struct {
+    seL4_BootInfoHeader header;
+    uint32_t value;
+} bootinfo_tsc_freq_t;
+bootinfo_tsc_freq_t *bootinfo_tsc_freq;
+#else
+#error "No example cases for this architecture"
+#endif
+
+void init(void)
+{
+    microkit_dbg_puts("====BootInfo====\n");
+#if defined(CONFIG_ARCH_X86_64)
+    if (bootinfo_tsc_freq->header.len) {
+        microkit_dbg_puts("TSC Frequency: ");
+        microkit_dbg_put32(bootinfo_tsc_freq->value);
+        microkit_dbg_puts("MHz\n");
+    } else {
+        microkit_dbg_puts("TSC Frequency is not found or prefilled properly.\n");
+    }
+#else
+#error "No example cases for this architecture"
+#endif
+}
+
+void notified(microkit_channel ch)
+{
+}

--- a/example/bootinfo/bootinfo.system
+++ b/example/bootinfo/bootinfo.system
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="bootinfo_x86_tsc_freq" prefill_bootinfo="x86_tsc_freq" />
+    <protection_domain name="bootinfo">
+        <program_image path="bootinfo.elf" />
+        <map mr="bootinfo_x86_tsc_freq" vaddr="0x2_000_000" perms="r" cached="true" setvar_vaddr="bootinfo_tsc_freq" />
+    </protection_domain>
+</system>

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use sel4_capdl_initializer_types::{
-    object, CapTableEntry, Fill, FillEntry, FillEntryContent, NamedObject, Object, ObjectId, Spec,
-    Word,
+    object, CapTableEntry, Fill, FillEntry, FillEntryContent, FillEntryContentBootInfo,
+    NamedObject, Object, ObjectId, Spec, Word,
 };
 
 use crate::{
@@ -513,8 +513,9 @@ pub fn build_capdl_spec(
                 .paddr()
                 .map(|base_paddr| Word(base_paddr + (frame_sequence * mr.page_size_bytes())));
 
+            let starting_byte_idx = frame_sequence * mr.page_size_bytes();
+
             let frame_fill = if let Some(prefill_bytes) = &mr.prefill_bytes {
-                let starting_byte_idx = frame_sequence * mr.page_size_bytes();
                 let remaining_bytes_to_fill = prefill_bytes.len() as u64 - starting_byte_idx;
                 let num_bytes_to_fill = min(mr.page_size_bytes(), remaining_bytes_to_fill);
 
@@ -535,6 +536,22 @@ pub fn build_capdl_spec(
                         })),
                     }]
                     .to_vec(),
+                }
+            } else if let Some(prefill_bootinfo) = mr.prefill_bootinfo {
+                let remaining_bytes_to_fill = mr.size - starting_byte_idx;
+                let num_bytes_to_fill = min(mr.page_size_bytes(), remaining_bytes_to_fill);
+
+                FrameFill {
+                    entries: vec![FillEntry {
+                        range: Range {
+                            start: 0,
+                            end: num_bytes_to_fill,
+                        },
+                        content: FillEntryContent::BootInfo(FillEntryContentBootInfo {
+                            id: prefill_bootinfo,
+                            offset: starting_byte_idx,
+                        }),
+                    }],
                 }
             } else {
                 FrameFill {

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -19,8 +19,10 @@
 use crate::sel4::{
     Arch, ArmRiscvIrqTrigger, Config, PageSize, X86IoapicIrqPolarity, X86IoapicIrqTrigger,
 };
+
 use crate::util::{get_full_path, ranges_overlap, round_up, str_to_bool};
 use crate::MAX_PDS;
+use sel4_capdl_initializer_types::FillEntryContentBootInfoId;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::fs;
@@ -116,6 +118,7 @@ pub enum SysMemoryRegionKind {
     User,
     Elf,
     Stack,
+    BootInfo,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -141,6 +144,7 @@ pub struct SysMemoryRegion {
     /// stack, ELF, etc.
     pub kind: SysMemoryRegionKind,
     pub prefill_bytes: Option<Vec<u8>>,
+    pub prefill_bootinfo: Option<FillEntryContentBootInfoId>,
 }
 
 impl SysMemoryRegion {
@@ -1432,6 +1436,7 @@ impl SysMemoryRegion {
         xml_sdf: &XmlSystemDescription,
         node: &roxmltree::Node,
         prefill_bytes_maybe: &Option<Vec<u8>>,
+        prefill_bootinfo_maybe: Option<FillEntryContentBootInfoId>,
         page_size: u64,
     ) -> Result<u64, String> {
         match checked_lookup(xml_sdf, node, "size") {
@@ -1468,15 +1473,19 @@ impl SysMemoryRegion {
             }
 
             Err(_) => {
-                // No size explicitly specified
-                match &prefill_bytes_maybe {
-                    Some(bytes) => Ok(round_up(bytes.len() as u64, page_size)),
+                if prefill_bootinfo_maybe.is_some() {
+                    Ok(page_size)
+                } else {
+                    // No size explicitly specified
+                    match &prefill_bytes_maybe {
+                        Some(bytes) => Ok(round_up(bytes.len() as u64, page_size)),
 
-                    None => Err(value_error(
-                        xml_sdf,
-                        node,
-                        "size must be specified if memory region is not prefilled".to_string(),
-                    )),
+                        None => Err(value_error(
+                            xml_sdf,
+                            node,
+                            "size must be specified if memory region is not prefilled".to_string(),
+                        )),
+                    }
                 }
             }
         }
@@ -1491,7 +1500,14 @@ impl SysMemoryRegion {
         check_attributes(
             xml_sdf,
             node,
-            &["name", "size", "page_size", "phys_addr", "prefill_path"],
+            &[
+                "name",
+                "size",
+                "page_size",
+                "phys_addr",
+                "prefill_path",
+                "prefill_bootinfo",
+            ],
         )?;
 
         let name = checked_lookup(xml_sdf, node, "name")?;
@@ -1548,7 +1564,44 @@ impl SysMemoryRegion {
             })
             .transpose()?;
 
-        let size = Self::determine_size(xml_sdf, node, &prefill_bytes_maybe, page_size)?;
+        let prefill_bootinfo_maybe = node
+            .attribute("prefill_bootinfo")
+            .map(|xml_bi_type| match xml_bi_type {
+                "x86_vbe" => Ok(FillEntryContentBootInfoId::X86Vbe),
+                "x86_mbmmap" => Ok(FillEntryContentBootInfoId::X86Mbmmap),
+                "x86_acpi_rsdp" => Ok(FillEntryContentBootInfoId::X86AcpiRsdp),
+                "x86_framebuffer" => Ok(FillEntryContentBootInfoId::X86FrameBuffer),
+                "x86_tsc_freq" => Ok(FillEntryContentBootInfoId::X86TscFreq),
+                "fdt" => Ok(FillEntryContentBootInfoId::Fdt),
+                _ => Err(value_error(
+                    xml_sdf,
+                    node,
+                    format!("BootInfoMap type: '{xml_bi_type}' is not supported"),
+                )),
+            })
+            .transpose()?;
+
+        if prefill_bytes_maybe.is_some() && prefill_bootinfo_maybe.is_some() {
+            return Err(value_error(
+                xml_sdf,
+                node,
+                "prefill_path and prefill_bootinfo cannot be both specified".to_string(),
+            ));
+        }
+
+        let mr_kind = if prefill_bootinfo_maybe.is_none() {
+            SysMemoryRegionKind::User
+        } else {
+            SysMemoryRegionKind::BootInfo
+        };
+
+        let size = Self::determine_size(
+            xml_sdf,
+            node,
+            &prefill_bytes_maybe,
+            prefill_bootinfo_maybe,
+            page_size,
+        )?;
 
         let phys_addr = if let Some(xml_phys_addr) = node.attribute("phys_addr") {
             SysMemoryRegionPaddr::Specified(sdf_parse_number(xml_phys_addr, node)?)
@@ -1577,8 +1630,9 @@ impl SysMemoryRegion {
             page_count,
             phys_addr,
             text_pos: Some(xml_sdf.doc.text_pos_at(node.range().start)),
-            kind: SysMemoryRegionKind::User,
+            kind: mr_kind,
             prefill_bytes: prefill_bytes_maybe,
+            prefill_bootinfo: prefill_bootinfo_maybe,
         })
     }
 }

--- a/tool/microkit/tests/sdf/mr_prefill_bootinfo_type_invalid.system
+++ b/tool/microkit/tests/sdf/mr_prefill_bootinfo_type_invalid.system
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="bootinfo" prefill_bootinfo="x86_invalid_bootinfo" />
+
+    <protection_domain name="mr_bootinfo" priority="100" >
+        <program_image path="mr_bootinfo.elf" />
+        <map mr="bootinfo" vaddr="0x20000000" setvar_vaddr="bootinfo_mr" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/mr_prefill_bootinfo_valid.system
+++ b/tool/microkit/tests/sdf/mr_prefill_bootinfo_valid.system
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="bootinfo" prefill_bootinfo="x86_tsc_freq" />
+
+    <protection_domain name="mr_bootinfo" priority="100" >
+        <program_image path="mr_bootinfo.elf" />
+        <map mr="bootinfo" vaddr="0x20000000" setvar_vaddr="bootinfo_mr" />
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/sdf/mr_prefill_path_bootinfo_both_specified.system
+++ b/tool/microkit/tests/sdf/mr_prefill_path_bootinfo_both_specified.system
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="prefilled" prefill_path="small.bin" prefill_bootinfo="x86_tsc_freq" />
+
+    <protection_domain name="mr_prefill" priority="100" >
+        <program_image path="mr_prefill.elf" />
+        <map mr="prefilled" vaddr="0x20000000" setvar_vaddr="filled_mr" setvar_prefill_size="filled_mr_data_size"/>
+    </protection_domain>
+</system>

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -236,6 +236,32 @@ mod memory_region {
             "mr_prefill_sized_valid.system",
         )
     }
+
+    #[test]
+    fn test_mr_prefill_bootinfo_valid() {
+        check_success(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "mr_prefill_bootinfo_valid.system",
+        )
+    }
+
+    #[test]
+    fn test_mr_prefill_bootinfo_type_invalid() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "mr_prefill_bootinfo_type_invalid.system",
+            "Error: BootInfoMap type: 'x86_invalid_bootinfo' is not supported on element 'memory_region'",
+        )
+    }
+
+    #[test]
+    fn test_mr_prefill_path_bootinfo_both_specified() {
+        check_error(
+            &DEFAULT_X86_64_KERNEL_CONFIG,
+            "mr_prefill_path_bootinfo_both_specified.system",
+            "Error: prefill_path and prefill_bootinfo cannot be both specified on element 'memory_region'",
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
~~This PR is rebased on branch [rust_sel4_update_to_main](https://github.com/au-ts/microkit/tree/rust_sel4_update_to_main), which should be merged soon. The proposed feature is included in the only last 3 commits.~~ (merged)

This PR adds the `bootinfo` tag to map specified type of bootinfo into PD's vspace, and patch the address to pre-declared variable `bootinfo_{bi_type}`. This is useful for the cases where the userspace applications needs to consume bootinfo, e.g., RSDP in ACPI driver, [TSC used as clock source](https://github.com/seL4/microkit/issues/525), etc.

The usage of `bootinfo` tag is added in the example `x86_64_ioport`. It works with [this rust-sel4 PR](https://github.com/seL4/rust-sel4/pull/355) on x86 to show how TSC frequency is mapped and read by a PD.

(On hold, waiting [rust-sel4 PR](https://github.com/seL4/rust-sel4/pull/355) to be merged)