### PR TITLE
rollback rust-sel4 to c30d0e4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sel4"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "cfg-if",
  "sel4-config",
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "sel4-alloca"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "cfg-if",
 ]
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "sel4-bitfield-ops"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "rustversion",
 ]
@@ -520,12 +520,12 @@ dependencies = [
 [[package]]
 name = "sel4-build-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-capdl-initializer"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "log",
  "rkyv",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "miniz_oxide",
  "rkyv",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "sel4-capdl-initializer-types-derive"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "sel4-config"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-data"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "sel4-build-env",
  "sel4-config-types",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "fallible-iterator",
  "proc-macro2",
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "serde",
 ]
@@ -610,12 +610,12 @@ dependencies = [
 [[package]]
 name = "sel4-ctors-dtors"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-dlmalloc"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "dlmalloc",
  "lock_api",
@@ -624,17 +624,17 @@ dependencies = [
 [[package]]
 name = "sel4-immediate-sync-once-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-immutable-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-initialize-tls"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "cfg-if",
  "sel4-alloca",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "sel4-logging"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "lock_api",
  "log",
@@ -652,12 +652,12 @@ dependencies = [
 [[package]]
 name = "sel4-no-allocator"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-panicking"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "cfg-if",
  "sel4-immediate-sync-once-cell",
@@ -668,12 +668,12 @@ dependencies = [
 [[package]]
 name = "sel4-panicking-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-phdrs"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "sel4-phdrs-constants",
 ]
@@ -681,12 +681,12 @@ dependencies = [
 [[package]]
 name = "sel4-phdrs-constants"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-phdrs-patched"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "sel4-phdrs",
  "sel4-rodata-static",
@@ -695,12 +695,12 @@ dependencies = [
 [[package]]
 name = "sel4-rodata-static"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-root-task"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "sel4",
  "sel4-dlmalloc",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "sel4-root-task-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "sel4-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -741,12 +741,12 @@ dependencies = [
 [[package]]
 name = "sel4-stack"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [[package]]
 name = "sel4-sync"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "lock_api",
  "sel4",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "sel4-sys"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4?rev=413940c8058da32098c464f6cd09e550b230505c#413940c8058da32098c464f6cd09e550b230505c"
+source = "git+https://github.com/seL4/rust-sel4?rev=c30d0e44fb32c15239049ce402ef2a8c72499aa3#c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 dependencies = [
  "bindgen",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ members = [
 
 [workspace.dependencies.sel4-capdl-initializer]
 git = "https://github.com/seL4/rust-sel4"
-rev = "413940c8058da32098c464f6cd09e550b230505c"
+rev = "c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [workspace.dependencies.sel4-capdl-initializer-types]
 git = "https://github.com/seL4/rust-sel4"
-rev = "413940c8058da32098c464f6cd09e550b230505c"
+rev = "c30d0e44fb32c15239049ce402ef2a8c72499aa3"
 
 [profile.release.package.microkit-tool]
 strip = true


### PR DESCRIPTION
The commit ahead (413940c) have a broken change to the initialiser that causes SError in EL0 on ARM due to incorrect untyped allocation.