### PR TITLE
tool: update capdl object allocation algorithm

### DIFF
--- a/tool/microkit/src/capdl/allocation.rs
+++ b/tool/microkit/src/capdl/allocation.rs
@@ -146,9 +146,7 @@ pub fn simulate_capdl_object_alloc_algorithm(
 
             while cur_paddr < target {
                 let max_size_bits = {
-                    let alignment_bits = (cur_paddr - ut.base())
-                        .checked_ilog2()
-                        .unwrap_or(kernel_config.word_size.try_into().unwrap());
+                    let alignment_bits = (cur_paddr - ut.base()).trailing_zeros();
                     let distance_bits = (target - cur_paddr).checked_ilog2().expect("never 0");
                     alignment_bits.min(distance_bits).try_into().unwrap()
                 };


### PR DESCRIPTION
The rust-sel4 commit was updated in bb1123e, which included a small change in the upstream capDL initialiser's object allocation algorithm. We also have to update our copy to keep them in sync.

We should improve this in the future so that we don't have to keep them in sync.