### PR TITLE
tool: parse channel and irq id attributes without panicking

### DIFF
--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -738,24 +738,19 @@ impl ProtectionDomain {
                     maps.push(map);
                 }
                 "irq" => {
-                    let id = checked_lookup(xml_sdf, &child, "id")?
-                        .parse::<i64>()
-                        .unwrap();
-                    if id > PD_MAX_ID as i64 {
+                    let id = sdf_parse_number(checked_lookup(xml_sdf, &child, "id")?, &child)?;
+                    if id > PD_MAX_ID {
                         return Err(value_error(
                             xml_sdf,
                             &child,
                             format!("id must be < {}", PD_MAX_ID + 1),
                         ));
                     }
-                    if id < 0 {
-                        return Err(value_error(xml_sdf, &child, "id must be >= 0".to_string()));
-                    }
 
                     if let Some(setvar_id) = child.attribute("setvar_id") {
                         let setvar = SysSetVar {
                             symbol: setvar_id.to_string(),
-                            kind: SysSetVarKind::Id { id: id as u64 },
+                            kind: SysSetVarKind::Id { id },
                         };
                         checked_add_setvar(&mut setvars, setvar, xml_sdf, &child)?;
                     }
@@ -789,7 +784,7 @@ impl ProtectionDomain {
                             ArmRiscvIrqTrigger::Level
                         };
                         let irq = SysIrq {
-                            id: id as u64,
+                            id,
                             kind: SysIrqKind::Conventional { irq, trigger },
                         };
                         irqs.push(irq);
@@ -884,7 +879,7 @@ impl ProtectionDomain {
                         }
 
                         let irq = SysIrq {
-                            id: id as u64,
+                            id,
                             kind: SysIrqKind::IOAPIC {
                                 ioapic: ioapic as u64,
                                 pin: pin as u64,
@@ -1022,7 +1017,7 @@ impl ProtectionDomain {
                         }
 
                         let irq = SysIrq {
-                            id: id as u64,
+                            id,
                             kind: SysIrqKind::MSI {
                                 pci_bus: pci_bus_maybe.unwrap() as u64,
                                 pci_dev: pci_dev_maybe.unwrap() as u64,
@@ -1054,28 +1049,19 @@ impl ProtectionDomain {
                             &["id", "setvar_id", "setvar_addr", "addr", "size"],
                         )?;
 
-                        let id = checked_lookup(xml_sdf, &child, "id")?
-                            .parse::<i64>()
-                            .unwrap();
-                        if id > PD_MAX_ID as i64 {
+                        let id = sdf_parse_number(checked_lookup(xml_sdf, &child, "id")?, &child)?;
+                        if id > PD_MAX_ID {
                             return Err(value_error(
                                 xml_sdf,
                                 &child,
                                 format!("id must be < {}", PD_MAX_ID + 1),
                             ));
                         }
-                        if id < 0 {
-                            return Err(value_error(
-                                xml_sdf,
-                                &child,
-                                "id must be >= 0".to_string(),
-                            ));
-                        }
 
                         if let Some(setvar_id) = child.attribute("setvar_id") {
                             let setvar = SysSetVar {
                                 symbol: setvar_id.to_string(),
-                                kind: SysSetVarKind::Id { id: id as u64 },
+                                kind: SysSetVarKind::Id { id },
                             };
                             checked_add_setvar(&mut setvars, setvar, xml_sdf, &child)?;
                         }
@@ -1103,7 +1089,7 @@ impl ProtectionDomain {
                         }
 
                         ioports.push(IOPort {
-                            id: id as u64,
+                            id,
                             addr,
                             size: size as u64,
                             text_pos: xml_sdf.doc.text_pos_at(node.range().start),
@@ -1655,18 +1641,14 @@ impl ChannelEnd {
 
         check_attributes(xml_sdf, node, &["pd", "id", "pp", "notify", "setvar_id"])?;
         let end_pd = checked_lookup(xml_sdf, node, "pd")?;
-        let end_id = checked_lookup(xml_sdf, node, "id")?.parse::<i64>().unwrap();
+        let end_id = sdf_parse_number(checked_lookup(xml_sdf, node, "id")?, node)?;
 
-        if end_id > PD_MAX_ID as i64 {
+        if end_id > PD_MAX_ID {
             return Err(value_error(
                 xml_sdf,
                 node,
                 format!("id must be < {}", PD_MAX_ID + 1),
             ));
-        }
-
-        if end_id < 0 {
-            return Err(value_error(xml_sdf, node, "id must be >= 0".to_string()));
         }
 
         let notify = node
@@ -1693,7 +1675,7 @@ impl ChannelEnd {
             let setvar_id = node.attribute("setvar_id").map(ToOwned::to_owned);
             Ok(ChannelEnd {
                 pd: pd_idx,
-                id: end_id.try_into().unwrap(),
+                id: end_id,
                 notify,
                 pp,
                 setvar_id,

--- a/tool/microkit/tests/sdf/ch_id_not_a_number.system
+++ b/tool/microkit/tests/sdf/ch_id_not_a_number.system
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+    </protection_domain>
+    <protection_domain name="test2">
+        <program_image path="test" />
+    </protection_domain>
+    <channel>
+        <end pd="test1" id="abc"/>
+        <end pd="test2" id="5"/>
+    </channel>
+</system>

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -452,7 +452,7 @@ mod protection_domain {
         check_error(
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "irq_id_less_than_0.system",
-            "Error: id must be >= 0 on element 'irq'",
+            "Error: failed to parse integer '-1' on element 'irq'",
         )
     }
 
@@ -875,7 +875,16 @@ mod channel {
         check_error(
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "ch_id_less_than_0.system",
-            "Error: id must be >= 0 on element 'end'",
+            "Error: failed to parse integer '-1' on element 'end'",
+        )
+    }
+
+    #[test]
+    fn test_id_not_a_number() {
+        check_error(
+            &DEFAULT_AARCH64_KERNEL_CONFIG,
+            "ch_id_not_a_number.system",
+            "Error: failed to parse integer 'abc' on element 'end'",
         )
     }
 


### PR DESCRIPTION
Closes #537.

The `id` attribute on channel ends, IRQs and IOPorts was parsed with `.parse::<i64>().unwrap()`, so a non-numeric value like `id="abc"` aborts the tool with a panic instead of a proper error. This switches those sites to the existing `sdf_parse_number` helper so they report a normal parse error like every other integer attribute, and drops the now-redundant `< 0` and cast handling. Added a channel test covering a non-numeric id and updated the two negative-id tests to the new message.