### PR TITLE
Remove support for a cap_cspace mapping

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1068,7 +1068,6 @@ It supports no attributes, but supports the following elements as children:
 * `cap_sc`: A capability to a protection domain's Scheduling Context (SC).
   If the protection domain is passive, this is a capability to the notification's scheduling context.
 * `cap_vspace`: A capability to a protection domain's VSpace.
-* `cap_cspace`: A capability to a protection domain's CSpace.
 
 All of the elements support the `slot` attribute, which is is an opaque identifier used to address the capability at runtime.
 To convert the `slot` to an `seL4_CPtr`, use the [`seL4_CPtr microkit_cspace_root_slot_to_cptr(seL4_Word slot)`](#libmicrokit_cspace_root_slot_to_cptr) function.

--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -1206,25 +1206,6 @@ pub fn build_capdl_spec(
                 CapMapType::Tcb => capdl_util_make_tcb_cap(pd_src_shadow_cspace.tcb),
                 CapMapType::Sc => capdl_util_make_sc_cap(pd_src_shadow_cspace.sched_context),
                 CapMapType::VSpace => capdl_util_make_page_table_cap(pd_src_shadow_cspace.vspace),
-                CapMapType::CSpace => {
-                    let Some(named_object) =
-                        spec_container.get_root_object(pd_src_shadow_cspace.cspace)
-                    else {
-                        unreachable!("internal bug: couldn't find cnode with given obj id.");
-                    };
-                    let Object::CNode(ref cnode) = named_object.object else {
-                        unreachable!(
-                            "internal bug: got a non-CNode object id {} with name '{}'",
-                            usize::from(pd_src_shadow_cspace.cspace),
-                            named_object.name.as_ref().unwrap()
-                        );
-                    };
-
-                    let guard_size =
-                        kernel_config.cap_address_bits as u8 - PD_ROOT_CAP_BITS - cnode.size_bits;
-
-                    capdl_util_make_cnode_cap(pd_src_shadow_cspace.cspace, 0, guard_size)
-                }
             };
 
             // Map this into the destination pd's cspace and the specified slot.

--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -310,7 +310,6 @@ pub enum CapMapType {
     Tcb,
     Sc,
     VSpace,
-    CSpace,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1437,7 +1436,6 @@ impl CSpace {
                 "cap_tcb" => CapMap::from_xml(CapMapType::Tcb, xml_sdf, &child)?,
                 "cap_sc" => CapMap::from_xml(CapMapType::Sc, xml_sdf, &child)?,
                 "cap_vspace" => CapMap::from_xml(CapMapType::VSpace, xml_sdf, &child)?,
-                "cap_cspace" => CapMap::from_xml(CapMapType::CSpace, xml_sdf, &child)?,
                 child_name => {
                     let location = loc_string(xml_sdf, xml_sdf.doc.text_pos_at(child.range().start));
                     if let Some(type_name) = child_name.strip_prefix("cap_") {

--- a/tool/microkit/tests/sdf/pd_cap_mappings_overlapping.system
+++ b/tool/microkit/tests/sdf/pd_cap_mappings_overlapping.system
@@ -21,9 +21,8 @@
             <cap_tcb    slot="1" pd="pd_a" />
             <cap_sc     slot="2" pd="pd_a" />
             <cap_vspace slot="3" pd="pd_a" />
-            <cap_cspace slot="4" pd="pd_a" />
             <!-- duplicate slot -->
-            <cap_cspace slot="4" pd="pd_a" />
+            <cap_vspace slot="3" pd="pd_a" />
         </cspace>
     </protection_domain>
 </system>

--- a/tool/microkit/tests/test.rs
+++ b/tool/microkit/tests/test.rs
@@ -1110,9 +1110,9 @@ mod system {
         check_error(
             &DEFAULT_AARCH64_KERNEL_CONFIG,
             "pd_cap_mappings_overlapping.system",
-            r#"Error: overlapping user caps in slot 4 of protection domain 'pd_b':
-  type CSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:24:13'
-  type CSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:26:13'"#,
+            r#"Error: overlapping user caps in slot 3 of protection domain 'pd_b':
+  type VSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:23:13'
+  type VSpace from 'pd_a' at 'pd_cap_mappings_overlapping.system:25:13'"#,
         )
     }
 


### PR DESCRIPTION
As per discussions surrounding RFC25, allowing access to a PD's CSpace can violate the static nature of a Microkit system. Let's remove this feature for now for the next release and we can always rework/add it back later.

It was also broken, and it did not work properly because of the guard.