### PR TITLE
libmicrokit: introduce 'microkit_pd_resume'

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -577,6 +577,7 @@ If the protection domain has children it must also implement:
     void microkit_deferred_irq_ack(microkit_channel ch);
     void microkit_pd_restart(microkit_child pd, seL4_Word entry_point);
     void microkit_pd_stop(microkit_child pd);
+    void microkit_pd_resume(microkit_child pd);
     void microkit_mr_set(seL4_Uint8 mr, seL4_Word value);
     seL4_Word microkit_mr_get(seL4_Uint8 mr);
     void microkit_vcpu_restart(microkit_child vcpu, seL4_Word entry_point);
@@ -754,6 +755,10 @@ This will set the program counter of the child protection domain to `entry_point
 ## `void microkit_pd_stop(microkit_child pd)`
 
 Stop the execution of the child protection domain with ID `pd`.
+
+## `void microkit_pd_resume(microkit_child pd)`
+
+Resume the execution of the child protection domain with ID `pd` that is stopped.
 
 ## `microkit_msginfo microkit_msginfo_new(uint64_t label, uint16_t count)`
 

--- a/libmicrokit/include/microkit.h
+++ b/libmicrokit/include/microkit.h
@@ -158,7 +158,21 @@ static inline void microkit_pd_stop(microkit_child pd)
     seL4_Error err;
     err = seL4_TCB_Suspend(BASE_TCB_CAP + pd);
     if (err != seL4_NoError) {
-        microkit_dbg_puts("microkit_pd_stop: error writing TCB registers\n");
+        microkit_dbg_puts("microkit_pd_stop: error stopping TCB '");
+        microkit_dbg_put32(pd);
+        microkit_dbg_puts("'\n");
+        microkit_internal_crash(err);
+    }
+}
+
+static inline void microkit_pd_resume(microkit_child pd)
+{
+    seL4_Error err;
+    err = seL4_TCB_Resume(BASE_TCB_CAP + pd);
+    if (err != seL4_NoError) {
+        microkit_dbg_puts("microkit_pd_resume: error resuming TCB '");
+        microkit_dbg_put32(pd);
+        microkit_dbg_puts("'\n");
         microkit_internal_crash(err);
     }
 }


### PR DESCRIPTION
This commit adds 'microkit_pd_resume' that resumes a PD that is stopped by 'microkit_pd_stop'.

Such a function prevents hand-writing life-cycle management code for dynamic PDs, which are useful for projects like [Carrels](https://trustworthy.systems/projects/Carrels)