### PR TITLE
domains: Set domain of VM VCPUs to domain of PD

### DIFF
--- a/tool/microkit/src/capdl/builder.rs
+++ b/tool/microkit/src/capdl/builder.rs
@@ -1020,7 +1020,7 @@ pub fn build_capdl_spec(
                             sp: Word(0),
                             gprs: [].to_vec(),
                             master_fault_ep: None, // Not used on MCS kernel.
-                            domain: None,
+                            domain: pd.domain,
                         }),
                     };
                     let vm_vcpu_tcb_obj_id = spec_container.add_root_object(NamedObject {


### PR DESCRIPTION
Performance of the VM VCPUs is quite off without being placed in a domain when the domain scheduler is being used.