### PR TITLE
tool: remove `roxmltree::Document` from `XmlSystemDescription`

### DIFF
--- a/tool/microkit/src/sdf.rs
+++ b/tool/microkit/src/sdf.rs
@@ -125,9 +125,8 @@ impl<'a> SdfNode<'a> for roxmltree::Node<'a, '_> {
     }
 }
 
-pub(crate) struct XmlSystemDescription<'a> {
+pub(crate) struct SystemDescriptionFile<'a> {
     filename: &'a Path,
-    doc: &'a roxmltree::Document<'a>,
 }
 
 #[derive(Debug)]
@@ -150,10 +149,7 @@ pub fn parse(
         Err(err) => return Err(format!("Could not parse '{0}': {err}", filename.display())),
     };
 
-    let xml_sdf = XmlSystemDescription {
-        filename,
-        doc: &doc,
-    };
+    let xml_sdf = SystemDescriptionFile { filename };
 
     let mut root_pds = vec![];
     let mut mrs = vec![];

--- a/tool/microkit/src/sdf/channels.rs
+++ b/tool/microkit/src/sdf/channels.rs
@@ -7,7 +7,7 @@
 use super::consts::*;
 use super::pd_vm::ProtectionDomain;
 use super::util::{check_attributes, checked_lookup, loc_string, value_error};
-use super::{SdfNode, XmlSystemDescription};
+use super::{SdfNode, SystemDescriptionFile};
 
 use crate::util::str_to_bool;
 
@@ -28,7 +28,7 @@ pub struct Channel {
 
 impl ChannelEnd {
     fn from_xml<'a>(
-        xml_sdf: &'a XmlSystemDescription,
+        xml_sdf: &'a SystemDescriptionFile,
         node: &'a dyn SdfNode,
         pds: &[ProtectionDomain],
     ) -> Result<ChannelEnd, String> {
@@ -102,7 +102,7 @@ impl Channel {
     /// with all the Protection Domains that could potentially be connected with
     /// the channel.
     pub(super) fn from_xml<'a>(
-        xml_sdf: &'a XmlSystemDescription,
+        xml_sdf: &'a SystemDescriptionFile,
         node: &'a dyn SdfNode,
         pds: &[ProtectionDomain],
     ) -> Result<Channel, String> {

--- a/tool/microkit/src/sdf/cspace.rs
+++ b/tool/microkit/src/sdf/cspace.rs
@@ -6,7 +6,7 @@
 
 use super::consts::*;
 use super::util::{check_attributes, checked_lookup, loc_string, sdf_parse_number, value_error};
-use super::{SdfLocation, SdfNode, XmlSystemDescription};
+use super::{SdfLocation, SdfNode, SystemDescriptionFile};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum CapMapType {
@@ -43,7 +43,7 @@ pub struct CSpace {
 impl CapMap {
     fn from_xml(
         cap_type: CapMapType,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
     ) -> Result<CapMap, String> {
         // At the moment the four cap maps we support all have the 'pd' element,
@@ -85,7 +85,7 @@ impl CapMap {
 
 impl CSpace {
     pub(super) fn from_xml(
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
     ) -> Result<Self, String> {
         check_attributes(xml_sdf, node, &[])?;

--- a/tool/microkit/src/sdf/domains.rs
+++ b/tool/microkit/src/sdf/domains.rs
@@ -10,7 +10,7 @@ use std::num::NonZero;
 use sel4_capdl_initializer_types::{DomainSchedDuration, DomainSchedEntry};
 
 use super::util::{check_attributes, checked_lookup, loc_string, sdf_parse_number, value_error};
-use super::{SdfNode, XmlSystemDescription};
+use super::{SdfNode, SystemDescriptionFile};
 
 use crate::Config;
 
@@ -25,7 +25,7 @@ pub struct Domains {
 impl Domains {
     pub(super) fn from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
     ) -> Result<Self, String> {
         check_attributes(xml_sdf, node, &[])?;
@@ -137,7 +137,7 @@ impl Domains {
 
     fn domain_from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
     ) -> Result<(String, Option<u8>), String> {
         check_attributes(xml_sdf, node, &["name", "id"])?;
@@ -171,7 +171,7 @@ impl Domains {
 
     fn domain_schedule_from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         name_to_id_map: HashMap<String, u8>,
     ) -> Result<Domains, String> {
@@ -264,7 +264,7 @@ impl Domains {
     }
 
     fn schedule_entry_from_xml(
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         name_to_id_map: &HashMap<String, u8>,
     ) -> Result<DomainSchedEntry, String> {

--- a/tool/microkit/src/sdf/iommu.rs
+++ b/tool/microkit/src/sdf/iommu.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use super::memory_region::SysIOMap;
 use super::pci::{PciDevice, PciDeviceParseError};
 use super::util::{check_attributes, checked_lookup, loc_string, sdf_parse_number, value_error};
-use super::{SdfNode, XmlSystemDescription};
+use super::{SdfNode, SystemDescriptionFile};
 
 use crate::{sel4::Arch, Config};
 
@@ -73,7 +73,7 @@ impl fmt::Display for IommuDeviceIdentifierParseError {
 impl IOAddressSpace {
     pub(super) fn from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         names: &mut HashSet<String>,
         domain_ids: &mut HashSet<u64>,

--- a/tool/microkit/src/sdf/memory_region.rs
+++ b/tool/microkit/src/sdf/memory_region.rs
@@ -14,7 +14,7 @@ use sel4_capdl_initializer_types::FillEntryContentBootInfoId;
 use super::iommu::IommuDeviceIdentifier;
 use super::util::location_suffix_format;
 use super::util::{check_attributes, checked_lookup, sdf_parse_number, value_error};
-use super::{SdfLocation, SdfNode, XmlSystemDescription};
+use super::{SdfLocation, SdfNode, SystemDescriptionFile};
 
 use crate::util::get_full_path;
 use crate::util::round_up;
@@ -255,7 +255,7 @@ pub struct SysIOMap {
 
 impl SysMap {
     pub(super) fn from_xml(
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         allow_setvar: bool,
         max_vaddr: u64,
@@ -333,7 +333,7 @@ impl SysMap {
 impl SysIOMap {
     pub(super) fn from_xml(
         _config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         name: &str,
         identifier: IommuDeviceIdentifier,
@@ -388,7 +388,7 @@ impl SysIOMap {
 
 impl SysMemoryRegion {
     fn determine_size(
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         prefill_bytes_maybe: &Option<Vec<u8>>,
         prefill_bootinfo_maybe: Option<FillEntryContentBootInfoId>,
@@ -448,7 +448,7 @@ impl SysMemoryRegion {
 
     pub(super) fn from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         search_paths: &Vec<PathBuf>,
     ) -> Result<SysMemoryRegion, String> {
@@ -594,7 +594,7 @@ impl SysMemoryRegion {
 
 // max_end is the first invalid virtual address
 pub fn check_maps<'a, M, I>(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     mrs: &[SysMemoryRegion],
     maps: I,
     address_space: &str,
@@ -672,7 +672,7 @@ where
 }
 
 pub fn check_io_maps(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     mrs: &[SysMemoryRegion],
     iomaps: &[SysIOMap],
 ) -> Result<(), String> {

--- a/tool/microkit/src/sdf/pd_vm.rs
+++ b/tool/microkit/src/sdf/pd_vm.rs
@@ -18,7 +18,7 @@ use super::pci::PciDevice;
 use super::util::{
     check_attributes, checked_add_setvar, checked_lookup, loc_string, sdf_parse_number, value_error,
 };
-use super::{SdfLocation, SdfNode, XmlSystemDescription};
+use super::{SdfLocation, SdfNode, SystemDescriptionFile};
 
 use crate::sel4::{Arch, ArmRiscvIrqTrigger, X86IoapicIrqPolarity, X86IoapicIrqTrigger};
 use crate::util::str_to_bool;
@@ -135,7 +135,7 @@ impl ProtectionDomain {
 
     pub(super) fn from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
         is_child: bool,
         domains: &Domains,
@@ -810,7 +810,7 @@ impl ProtectionDomain {
 /// In doing so the representation is changed from "Node with list of children",
 /// to each node having a parent link instead.
 pub fn pd_flatten(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     pds: Vec<ProtectionDomain>,
 ) -> Result<Vec<ProtectionDomain>, String> {
     let mut all_pds = vec![];
@@ -830,7 +830,7 @@ pub fn pd_flatten(
 /// For example if PD A had children B, C then we would have [A, B, C].
 /// If we had the same example but child B also had a child D, we would have [A, B, D, C].
 fn pd_tree_to_list(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     mut pd: ProtectionDomain,
     idx: usize,
 ) -> Result<Vec<ProtectionDomain>, String> {
@@ -898,7 +898,7 @@ pub struct VirtualCpu {
 impl VirtualMachine {
     fn from_xml(
         config: &Config,
-        xml_sdf: &XmlSystemDescription,
+        xml_sdf: &SystemDescriptionFile,
         node: &dyn SdfNode,
     ) -> Result<VirtualMachine, String> {
         if config.arch == Arch::Aarch64 {

--- a/tool/microkit/src/sdf/util.rs
+++ b/tool/microkit/src/sdf/util.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-use super::{SdfLocation, SdfNode, SysSetVar, XmlSystemDescription};
+use super::{SdfLocation, SdfNode, SysSetVar, SystemDescriptionFile};
 
 /// The purpose of this function is to parse an integer that could
 /// either be in decimal or hex format, unlike the normal parsing
@@ -31,14 +31,14 @@ pub fn sdf_parse_number(s: &str, node: &dyn SdfNode) -> Result<u64, String> {
     }
 }
 
-pub fn loc_string(xml_sdf: &XmlSystemDescription, pos: SdfLocation) -> String {
+pub fn loc_string(xml_sdf: &SystemDescriptionFile, pos: SdfLocation) -> String {
     format!("{}:{}:{}", xml_sdf.filename.display(), pos.row, pos.col)
 }
 
 pub fn checked_add_setvar(
     setvars: &mut Vec<SysSetVar>,
     setvar: SysSetVar,
-    xml_sdf: &XmlSystemDescription<'_>,
+    xml_sdf: &SystemDescriptionFile<'_>,
     node: &dyn SdfNode<'_>,
 ) -> Result<(), String> {
     // Check that the symbol does not already exist
@@ -57,9 +57,12 @@ pub fn checked_add_setvar(
     Ok(())
 }
 
-pub fn check_no_text(xml_sdf: &XmlSystemDescription, node: &roxmltree::Node) -> Result<(), String> {
+pub fn check_no_text(
+    xml_sdf: &SystemDescriptionFile,
+    node: &roxmltree::Node,
+) -> Result<(), String> {
     let name = node.tag_name().name();
-    let pos = xml_sdf.doc.text_pos_at(node.range().start);
+    let pos = node.document().text_pos_at(node.range().start);
     let pos = SdfLocation {
         row: pos.row,
         col: pos.col,
@@ -94,7 +97,7 @@ pub fn check_no_text(xml_sdf: &XmlSystemDescription, node: &roxmltree::Node) -> 
 }
 
 pub fn check_attributes(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     node: &dyn SdfNode,
     attributes: &[&'static str],
 ) -> Result<(), String> {
@@ -112,7 +115,7 @@ pub fn check_attributes(
 }
 
 pub fn checked_lookup<'a>(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     node: &'a dyn SdfNode,
     attribute: &'static str,
 ) -> Result<&'a str, String> {
@@ -131,7 +134,7 @@ pub fn checked_lookup<'a>(
     }
 }
 
-pub fn value_error(xml_sdf: &XmlSystemDescription, node: &dyn SdfNode, err: String) -> String {
+pub fn value_error(xml_sdf: &SystemDescriptionFile, node: &dyn SdfNode, err: String) -> String {
     let pos = node.range().start;
     format!(
         "Error: {} on element '{}': {}:{}:{}",
@@ -144,7 +147,7 @@ pub fn value_error(xml_sdf: &XmlSystemDescription, node: &dyn SdfNode, err: Stri
 }
 
 pub fn location_suffix_format(
-    xml_sdf: &XmlSystemDescription,
+    xml_sdf: &SystemDescriptionFile,
     text_pos: Option<SdfLocation>,
 ) -> String {
     text_pos


### PR DESCRIPTION
This is the final change needed to allow for Microkit Tool to be used as a library without having any requirement of using XML for SDF parsing. `XmlSystemDescription` was also renamed to align with the fact it is not dependent on any XML anymore.